### PR TITLE
Combine persist transactions into one

### DIFF
--- a/src/Core/ComponentInterfaces/IPersist.cs
+++ b/src/Core/ComponentInterfaces/IPersist.cs
@@ -431,6 +431,9 @@ namespace SS.Core.ComponentInterfaces
         /// <returns><see langword="true"/> on success. <see langword="false"/> on failure.</returns>
         bool Close();
 
+        bool BeginTransaction();
+        void CommitTransaction();
+
         /// <summary>
         /// Creates a new interval for an arena group and makes it the "current" one.
         /// </summary>

--- a/src/Core/Modules/Persist.cs
+++ b/src/Core/Modules/Persist.cs
@@ -662,6 +662,9 @@ namespace SS.Core.Modules
 
                 // Sync all players.
                 HashSet<Player> players = _objectPoolManager.PlayerSetPool.Get();
+
+                _persistDatastore.BeginTransaction();
+
                 try
                 {
                     // Determine which players to process.
@@ -735,6 +738,8 @@ namespace SS.Core.Modules
 
                 // Sync global data.
                 DoPutArena(null);
+
+                _persistDatastore.CommitTransaction();
 
                 _nextSync = DateTime.UtcNow + _syncTimeSpan;
             }


### PR DESCRIPTION
Combine all of the write commands into one transaction instead of many to improve the write performance.

SetPlayerData, DeletePlayerData, SetArenaData, and DeleteArenaData are updated to use the batch transaction for their commands if it exists, otherwise it creates a new one-shot transaction.

Persist time went from 3200ms to 35-40ms for me with this change.

I don't know C# very well, so feel free to reject this pr or rewrite it. This should be proof of concept for using one transaction at least.