### PR TITLE
Ensures both kill points and flag points can be used to buy items.

### DIFF
--- a/src/Core/Modules/Buy.cs
+++ b/src/Core/Modules/Buy.cs
@@ -179,11 +179,12 @@ namespace SS.Core.Modules
                 return;
             }
 
-            if (!_arenaPlayerStats.TryGetStat(player, StatCodes.KillPoints, PersistInterval.Reset, out long killPoints)
-                || !_arenaPlayerStats.TryGetStat(player, StatCodes.FlagPoints, PersistInterval.Reset, out long flagPoints)
-                || killPoints + flagPoints < cost)
+            _arenaPlayerStats.TryGetStat(player, StatCodes.KillPoints, PersistInterval.Reset, out long killPoints);
+            _arenaPlayerStats.TryGetStat(player, StatCodes.FlagPoints, PersistInterval.Reset, out long flagPoints);
+
+            if(killPoints + flagPoints < cost)
             {
-                _chat.SendMessage(player, "You don't have enough points to purchase that item.");
+                _chat.SendMessage(player, $"You don't have enough points ({cost}) to purchase that item.");
                 return;
             }
 


### PR DESCRIPTION
In the previous implementation, sometimes kill points or flag points wouldn't have the correct value (as all the logic happened in the condition). It also adds a way of letting users know how many points the item they want to buy costs if they don't have enough points.