### PR TITLE
Update RemoveAllItems in TeamVersus to use player.ship instead of slot.ship..

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -3938,7 +3938,7 @@ namespace SS.Matchmaking.Modules
             if (arena is null || !_arenaDataDictionary.TryGetValue(arena, out ArenaData? arenaData))
                 return;
 
-            ref ShipSettings shipSettings = ref arenaData.ShipSettings[(int)slot.Ship];
+            ref ShipSettings shipSettings = ref arenaData.ShipSettings[(int)player.Ship];
             AdjustItem(player, Prize.Burst, shipSettings.InitialBurst);
             AdjustItem(player, Prize.Repel, shipSettings.InitialRepel);
             AdjustItem(player, Prize.Thor, shipSettings.InitialThor);


### PR DESCRIPTION
Update RemoveAllItems in TeamVersus to use player.ship instead of slot.ship as slot.ship was always coming across as "Warbird" causing only the initial items configured for a Warbird to be removed when using BurnItemsOnSpawn.