### PR TITLE
Filter out kill messages for players who are in a different match

### DIFF
--- a/src/Core/ComponentAdvisors/IKillAdvisor.cs
+++ b/src/Core/ComponentAdvisors/IKillAdvisor.cs
@@ -1,4 +1,6 @@
-﻿namespace SS.Core.ComponentAdvisors
+﻿using System.Collections.Generic;
+
+namespace SS.Core.ComponentAdvisors
 {
     /// <summary>
     /// Interface for an adivsor on kill activities.
@@ -24,5 +26,16 @@
         /// <param name="killed">The player who got killed.</param>
         /// <param name="bounty">The number displayed in the kill message.</param>
         void EditDeath(Arena arena, ref Player killer, ref Player killed, ref short bounty) { }
+
+        /// <summary>
+        /// Filters which players in the arena receive the S2C Kill notification packet.
+        /// </summary>
+        /// <param name="arena">The arena the kill took place in.</param>
+        /// <param name="killer">The player who made the kill.</param>
+        /// <param name="killed">The player who got killed.</param>
+        /// <param name="recipients">
+        /// The set of players who will receive the kill notification. Remove players from this set to suppress the packet for them.
+        /// </param>
+        void FilterKillNotification(Arena arena, Player killer, Player killed, HashSet<Player> recipients) { }
     }
 }

--- a/src/Core/Modules/Game.cs
+++ b/src/Core/Modules/Game.cs
@@ -2310,22 +2310,26 @@ namespace SS.Core.Modules
             var killAdvisors = arena.GetAdvisors<IKillAdvisor>();
             if (!killAdvisors.IsEmpty)
             {
-                HashSet<Player> recipients = new();
-                _playerData.Lock();
+                HashSet<Player> recipients = _objectPoolManager.PlayerSetPool.Get();
                 try
                 {
-                    foreach (Player p in _playerData.Players)
+                    _playerData.Lock();
+                    try
                     {
-                        if (p.Status == PlayerState.Playing && p.Arena == arena)
-                            recipients.Add(p);
+                        foreach (Player p in _playerData.Players)
+                        {
+                            if (p.Status == PlayerState.Playing && p.Arena == arena)
+                                recipients.Add(p);
+                        }
                     }
+                    finally { _playerData.Unlock(); }
+
+                    foreach (var advisor in killAdvisors)
+                        advisor.FilterKillNotification(arena, killer, killed, recipients);
+
+                    _network.SendToSet(recipients, ref packet, NetSendFlags.Reliable);
                 }
-                finally { _playerData.Unlock(); }
-
-                foreach (var advisor in killAdvisors)
-                    advisor.FilterKillNotification(arena, killer, killed, recipients);
-
-                _network.SendToSet(recipients, ref packet, NetSendFlags.Reliable);
+                finally { _objectPoolManager.PlayerSetPool.Return(recipients); }
             }
             else
             {

--- a/src/Core/Modules/Game.cs
+++ b/src/Core/Modules/Game.cs
@@ -2306,7 +2306,32 @@ namespace SS.Core.Modules
                 return;
 
             S2C_Kill packet = new(green, (short)killer.Id, (short)killed.Id, pts, flagCount);
-            _network.SendToArena(arena, null, ref packet, NetSendFlags.Reliable);
+
+            var killAdvisors = arena.GetAdvisors<IKillAdvisor>();
+            if (!killAdvisors.IsEmpty)
+            {
+                HashSet<Player> recipients = new();
+                _playerData.Lock();
+                try
+                {
+                    foreach (Player p in _playerData.Players)
+                    {
+                        if (p.Status == PlayerState.Playing && p.Arena == arena)
+                            recipients.Add(p);
+                    }
+                }
+                finally { _playerData.Unlock(); }
+
+                foreach (var advisor in killAdvisors)
+                    advisor.FilterKillNotification(arena, killer, killed, recipients);
+
+                _network.SendToSet(recipients, ref packet, NetSendFlags.Reliable);
+            }
+            else
+            {
+                _network.SendToArena(arena, null, ref packet, NetSendFlags.Reliable);
+            }
+
             _chatNetwork?.SendToArena(arena, null, $"KILL:{killer.Name}:{killed.Name}:{pts:D}:{flagCount:D}");
         }
 

--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -632,6 +632,9 @@ namespace SS.Matchmaking.Modules
 
         void IKillAdvisor.FilterKillNotification(Arena arena, Player killer, Player killed, HashSet<Player> recipients)
         {
+            if (!_arenaDataDictionary.TryGetValue(arena, out ArenaData? arenaData) || !arenaData.FilterKillPackets)
+                return;
+
             // Determine which match this kill belongs to.
             if (!killed.TryGetExtraData(_pdKey, out PlayerData? killedData) || killedData.AssignedSlot is null)
                 return; // Not a matchmaking kill — don't filter.
@@ -786,6 +789,8 @@ namespace SS.Matchmaking.Modules
 
         [ConfigHelp<bool>("SS.Matchmaking.TeamVersusMatch", "PublicPlayEnabled", ConfigScope.Arena, Default = false,
             Description = "Whether to allow players into ships without being in a match.")]
+        [ConfigHelp<bool>("SS.Matchmaking.TeamVersusMatch", "FilterKillPackets", ConfigScope.Arena, Default = false,
+            Description = "Whether to suppress kill notification packets for players assigned to a different match. Spectators (not assigned to any match) always receive all kill notifications.")]
         private void Callback_ArenaAction(Arena arena, ArenaAction action)
         {
             bool isRegisteredArena = false;
@@ -825,6 +830,7 @@ namespace SS.Matchmaking.Modules
                 }
 
                 arenaData.PublicPlayEnabled = _configManager.GetBool(ch, "SS.Matchmaking.TeamVersusMatch", "PublicPlayEnabled", false);
+                arenaData.FilterKillPackets = _configManager.GetBool(ch, "SS.Matchmaking.TeamVersusMatch", "FilterKillPackets", false);
 
                 // Register callbacks.
                 KillCallback.Register(arena, Callback_Kill);
@@ -7648,6 +7654,11 @@ namespace SS.Matchmaking.Modules
             public bool PublicPlayEnabled = false;
 
             /// <summary>
+            /// Whether kill notification packets are suppressed for players assigned to a different match.
+            /// </summary>
+            public bool FilterKillPackets = false;
+
+            /// <summary>
             /// A league match reserves control over the entire arena.
             /// </summary>
             public MatchData? LeagueMatch;
@@ -7660,6 +7671,7 @@ namespace SS.Matchmaking.Modules
                 ILeagueHelpToken = null;
                 Array.Clear(ShipSettings);
                 PublicPlayEnabled = false;
+                FilterKillPackets = false;
                 ReplayRecordingFilePath = null;
 
                 return true;

--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -54,7 +54,7 @@ namespace SS.Matchmaking.Modules
         Manages team versus matches.
         Configuration: {nameof(TeamVersusMatch)}.conf
         """)]
-    public sealed class TeamVersusMatch : IAsyncModule, IMatchmakingQueueAdvisor, IFreqManagerEnforcerAdvisor, IMatchFocusAdvisor, ILeagueGameMode, ILeagueHelp
+    public sealed class TeamVersusMatch : IAsyncModule, IMatchmakingQueueAdvisor, IFreqManagerEnforcerAdvisor, IMatchFocusAdvisor, IKillAdvisor, ILeagueGameMode, ILeagueHelp
     {
         private const string ConfigurationFileName = "TeamVersus.conf";
 
@@ -84,6 +84,7 @@ namespace SS.Matchmaking.Modules
 
         private AdvisorRegistrationToken<IMatchFocusAdvisor>? _iMatchFocusAdvisorToken;
         private AdvisorRegistrationToken<IMatchmakingQueueAdvisor>? _iMatchmakingQueueAdvisorToken;
+        private AdvisorRegistrationToken<IKillAdvisor>? _iKillAdvisorToken;
 
         private ConfigHandle? _teamVersusConfig;
         private PlayerDataKey<PlayerData> _pdKey;
@@ -252,6 +253,7 @@ namespace SS.Matchmaking.Modules
 
             _iMatchFocusAdvisorToken = broker.RegisterAdvisor<IMatchFocusAdvisor>(this);
             _iMatchmakingQueueAdvisorToken = broker.RegisterAdvisor<IMatchmakingQueueAdvisor>(this);
+            _iKillAdvisorToken = broker.RegisterAdvisor<IKillAdvisor>(this);
             return true;
 
             bool GetSpawnClientSettingIdentifiers()
@@ -288,6 +290,9 @@ namespace SS.Matchmaking.Modules
                 return Task.FromResult(false);
 
             if (!broker.UnregisterAdvisor(ref _iMatchmakingQueueAdvisorToken))
+                return Task.FromResult(false);
+
+            if (!broker.UnregisterAdvisor(ref _iKillAdvisorToken))
                 return Task.FromResult(false);
 
             _commandManager.RemoveCommand("loadmatchtype", Command_loadmatchtype);
@@ -619,6 +624,33 @@ namespace SS.Matchmaking.Modules
                 return null;
 
             return playerData.AssignedSlot?.MatchData;
+        }
+
+        #endregion
+
+        #region IKillAdvisor
+
+        void IKillAdvisor.FilterKillNotification(Arena arena, Player killer, Player killed, HashSet<Player> recipients)
+        {
+            // Determine which match this kill belongs to.
+            if (!killed.TryGetExtraData(_pdKey, out PlayerData? killedData) || killedData.AssignedSlot is null)
+                return; // Not a matchmaking kill — don't filter.
+
+            IMatch killedMatch = killedData.AssignedSlot.MatchData;
+
+            // Remove any player that is focused on a different match.
+            // Players with no focused match (e.g. unaffiliated spectators) are left in.
+            List<Player>? toRemove = null;
+            foreach (Player recipient in recipients)
+            {
+                IMatch? focusedMatch = _matchFocus.GetFocusedMatch(recipient);
+                if (focusedMatch is not null && focusedMatch != killedMatch)
+                    (toRemove ??= new()).Add(recipient);
+            }
+
+            if (toRemove is not null)
+                foreach (Player p in toRemove)
+                    recipients.Remove(p);
         }
 
         #endregion

--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -636,15 +636,18 @@ namespace SS.Matchmaking.Modules
             if (!killed.TryGetExtraData(_pdKey, out PlayerData? killedData) || killedData.AssignedSlot is null)
                 return; // Not a matchmaking kill — don't filter.
 
-            IMatch killedMatch = killedData.AssignedSlot.MatchData;
+            MatchData killedMatch = killedData.AssignedSlot.MatchData;
 
-            // Remove any player that is focused on a different match.
-            // Players with no focused match (e.g. unaffiliated spectators) are left in.
+            // Only suppress players who are assigned to a different match.
+            // Spectators (no assigned slot) are left in and receive all kill messages.
             List<Player>? toRemove = null;
             foreach (Player recipient in recipients)
             {
-                IMatch? focusedMatch = _matchFocus.GetFocusedMatch(recipient);
-                if (focusedMatch is not null && focusedMatch != killedMatch)
+                if (!recipient.TryGetExtraData(_pdKey, out PlayerData? recipientData))
+                    continue;
+
+                MatchData? recipientMatch = recipientData.AssignedSlot?.MatchData;
+                if (recipientMatch is not null && recipientMatch != killedMatch)
                     (toRemove ??= new()).Add(recipient);
             }
 


### PR DESCRIPTION
Players will only get kill messages from the match they are in. Spectators will get kill messages from all matches