### PR TITLE
FilterKillPackets fix

### DIFF
--- a/src/Matchmaking/Modules/MatchFocus.cs
+++ b/src/Matchmaking/Modules/MatchFocus.cs
@@ -2,6 +2,7 @@
 using SS.Core;
 using SS.Core.ComponentAdvisors;
 using SS.Core.ComponentCallbacks;
+using System.Collections.Generic;
 using SS.Core.ComponentInterfaces;
 using SS.Matchmaking.Advisors;
 using SS.Matchmaking.Callbacks;
@@ -23,7 +24,7 @@ namespace SS.Matchmaking.Modules
         IGame game,
         ILogManager logManager,
         IObjectPoolManager objectPoolManager,
-        IPlayerData playerData) : IModule, IArenaAttachableModule, IMatchFocus, IPlayerPositionAdvisor, IBricksAdvisor
+        IPlayerData playerData) : IModule, IArenaAttachableModule, IMatchFocus, IPlayerPositionAdvisor, IBricksAdvisor, IKillAdvisor
     {
         private readonly IComponentBroker _broker = broker ?? throw new ArgumentNullException(nameof(broker));
         private readonly IGame _game = game ?? throw new ArgumentNullException(nameof(game));
@@ -93,6 +94,7 @@ namespace SS.Matchmaking.Modules
             SpectateChangedCallback.Register(arena, Callback_SpectateChanged);
             arenaData.IPlayerPositionAdvisorRegistrationToken = arena.RegisterAdvisor<IPlayerPositionAdvisor>(this);
             arenaData.IBricksAdvisorRegistrationToken = arena.RegisterAdvisor<IBricksAdvisor>(this);
+            arenaData.IKillAdvisorRegistrationToken = arena.RegisterAdvisor<IKillAdvisor>(this);
 
             return true;
         }
@@ -106,6 +108,9 @@ namespace SS.Matchmaking.Modules
                 return false;
 
             if (!arena.UnregisterAdvisor(ref arenaData.IBricksAdvisorRegistrationToken))
+                return false;
+
+            if (!arena.UnregisterAdvisor(ref arenaData.IKillAdvisorRegistrationToken))
                 return false;
 
             if (!_arenaDataDictionary.Remove(arena))
@@ -162,6 +167,29 @@ namespace SS.Matchmaking.Modules
             }
 
             return false;
+        }
+
+        #endregion
+
+        #region IKillAdvisor
+
+        void IKillAdvisor.FilterKillNotification(Arena arena, Player killer, Player killed, HashSet<Player> recipients)
+        {
+            if (!killed.TryGetExtraData(_playerDataKey, out PlayerData? killedData))
+                return;
+
+            MatchFocusData? killedMatch = killedData.PlayingInMatch;
+
+            List<Player>? toRemove = null;
+            foreach (Player recipient in recipients)
+            {
+                if (GetFocusedMatchData(recipient) != killedMatch)
+                    (toRemove ??= []).Add(recipient);
+            }
+
+            if (toRemove is not null)
+                foreach (Player p in toRemove)
+                    recipients.Remove(p);
         }
 
         #endregion
@@ -692,11 +720,13 @@ namespace SS.Matchmaking.Modules
         {
             public AdvisorRegistrationToken<IPlayerPositionAdvisor>? IPlayerPositionAdvisorRegistrationToken;
             public AdvisorRegistrationToken<IBricksAdvisor>? IBricksAdvisorRegistrationToken;
+            public AdvisorRegistrationToken<IKillAdvisor>? IKillAdvisorRegistrationToken;
 
             bool IResettable.TryReset()
             {
                 IPlayerPositionAdvisorRegistrationToken = null;
                 IBricksAdvisorRegistrationToken = null;
+                IKillAdvisorRegistrationToken = null;
                 return true;
             }
         }

--- a/src/Matchmaking/Modules/MatchFocus.cs
+++ b/src/Matchmaking/Modules/MatchFocus.cs
@@ -21,12 +21,14 @@ namespace SS.Matchmaking.Modules
     /// </remarks>
     public sealed class MatchFocus(
         IComponentBroker broker,
+        IConfigManager configManager,
         IGame game,
         ILogManager logManager,
         IObjectPoolManager objectPoolManager,
         IPlayerData playerData) : IModule, IArenaAttachableModule, IMatchFocus, IPlayerPositionAdvisor, IBricksAdvisor, IKillAdvisor
     {
         private readonly IComponentBroker _broker = broker ?? throw new ArgumentNullException(nameof(broker));
+        private readonly IConfigManager _configManager = configManager ?? throw new ArgumentNullException(nameof(configManager));
         private readonly IGame _game = game ?? throw new ArgumentNullException(nameof(game));
         private readonly ILogManager _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
         private readonly IObjectPoolManager _objectPoolManager = objectPoolManager ?? throw new ArgumentNullException(nameof(objectPoolManager));
@@ -95,6 +97,16 @@ namespace SS.Matchmaking.Modules
             arenaData.IPlayerPositionAdvisorRegistrationToken = arena.RegisterAdvisor<IPlayerPositionAdvisor>(this);
             arenaData.IBricksAdvisorRegistrationToken = arena.RegisterAdvisor<IBricksAdvisor>(this);
             arenaData.IKillAdvisorRegistrationToken = arena.RegisterAdvisor<IKillAdvisor>(this);
+
+            ConfigHandle ch = _configManager.OpenConfigFile(arena.BaseName, null);
+            try
+            {
+                arenaData.FilterKillPackets = _configManager.GetBool(ch, "SS.Matchmaking.MatchFocus", "FilterKillPackets", false);
+            }
+            finally
+            {
+                _configManager.CloseConfigFile(ch);
+            }
 
             return true;
         }
@@ -173,8 +185,13 @@ namespace SS.Matchmaking.Modules
 
         #region IKillAdvisor
 
+        [ConfigHelp<bool>("SS.Matchmaking.MatchFocus", "FilterKillPackets", ConfigScope.Arena, Default = false,
+            Description = "Whether to suppress kill notification packets for players not focused on the same match. Spectators watching a specific match see only that match's kills; unattached spectators see all kills.")]
         void IKillAdvisor.FilterKillNotification(Arena arena, Player killer, Player killed, HashSet<Player> recipients)
         {
+            if (!_arenaDataDictionary.TryGetValue(arena, out ArenaData? arenaData) || !arenaData.FilterKillPackets)
+                return;
+
             if (!killed.TryGetExtraData(_playerDataKey, out PlayerData? killedData))
                 return;
 
@@ -721,12 +738,14 @@ namespace SS.Matchmaking.Modules
             public AdvisorRegistrationToken<IPlayerPositionAdvisor>? IPlayerPositionAdvisorRegistrationToken;
             public AdvisorRegistrationToken<IBricksAdvisor>? IBricksAdvisorRegistrationToken;
             public AdvisorRegistrationToken<IKillAdvisor>? IKillAdvisorRegistrationToken;
+            public bool FilterKillPackets;
 
             bool IResettable.TryReset()
             {
                 IPlayerPositionAdvisorRegistrationToken = null;
                 IBricksAdvisorRegistrationToken = null;
                 IKillAdvisorRegistrationToken = null;
+                FilterKillPackets = false;
                 return true;
             }
         }

--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -54,7 +54,7 @@ namespace SS.Matchmaking.Modules
         Manages team versus matches.
         Configuration: {nameof(TeamVersusMatch)}.conf
         """)]
-    public sealed class TeamVersusMatch : IAsyncModule, IMatchmakingQueueAdvisor, IFreqManagerEnforcerAdvisor, IMatchFocusAdvisor, IKillAdvisor, ILeagueGameMode, ILeagueHelp
+    public sealed class TeamVersusMatch : IAsyncModule, IMatchmakingQueueAdvisor, IFreqManagerEnforcerAdvisor, IMatchFocusAdvisor, ILeagueGameMode, ILeagueHelp
     {
         private const string ConfigurationFileName = "TeamVersus.conf";
 
@@ -84,7 +84,7 @@ namespace SS.Matchmaking.Modules
 
         private AdvisorRegistrationToken<IMatchFocusAdvisor>? _iMatchFocusAdvisorToken;
         private AdvisorRegistrationToken<IMatchmakingQueueAdvisor>? _iMatchmakingQueueAdvisorToken;
-        private AdvisorRegistrationToken<IKillAdvisor>? _iKillAdvisorToken;
+
 
         private ConfigHandle? _teamVersusConfig;
         private PlayerDataKey<PlayerData> _pdKey;
@@ -253,7 +253,7 @@ namespace SS.Matchmaking.Modules
 
             _iMatchFocusAdvisorToken = broker.RegisterAdvisor<IMatchFocusAdvisor>(this);
             _iMatchmakingQueueAdvisorToken = broker.RegisterAdvisor<IMatchmakingQueueAdvisor>(this);
-            _iKillAdvisorToken = broker.RegisterAdvisor<IKillAdvisor>(this);
+
             return true;
 
             bool GetSpawnClientSettingIdentifiers()
@@ -292,8 +292,6 @@ namespace SS.Matchmaking.Modules
             if (!broker.UnregisterAdvisor(ref _iMatchmakingQueueAdvisorToken))
                 return Task.FromResult(false);
 
-            if (!broker.UnregisterAdvisor(ref _iKillAdvisorToken))
-                return Task.FromResult(false);
 
             _commandManager.RemoveCommand("loadmatchtype", Command_loadmatchtype);
             _commandManager.RemoveCommand("unloadmatchtype", Command_unloadmatchtype);
@@ -628,39 +626,6 @@ namespace SS.Matchmaking.Modules
 
         #endregion
 
-        #region IKillAdvisor
-
-        void IKillAdvisor.FilterKillNotification(Arena arena, Player killer, Player killed, HashSet<Player> recipients)
-        {
-            if (!_arenaDataDictionary.TryGetValue(arena, out ArenaData? arenaData) || !arenaData.FilterKillPackets)
-                return;
-
-            // Determine which match this kill belongs to.
-            if (!killed.TryGetExtraData(_pdKey, out PlayerData? killedData) || killedData.AssignedSlot is null)
-                return; // Not a matchmaking kill — don't filter.
-
-            MatchData killedMatch = killedData.AssignedSlot.MatchData;
-
-            // Only suppress players who are assigned to a different match.
-            // Spectators (no assigned slot) are left in and receive all kill messages.
-            List<Player>? toRemove = null;
-            foreach (Player recipient in recipients)
-            {
-                if (!recipient.TryGetExtraData(_pdKey, out PlayerData? recipientData))
-                    continue;
-
-                MatchData? recipientMatch = recipientData.AssignedSlot?.MatchData;
-                if (recipientMatch is not null && recipientMatch != killedMatch)
-                    (toRemove ??= new()).Add(recipient);
-            }
-
-            if (toRemove is not null)
-                foreach (Player p in toRemove)
-                    recipients.Remove(p);
-        }
-
-        #endregion
-
         #region ILeagueGameMode
 
         ILeagueMatch? ILeagueGameMode.CreateMatch(LeagueGameInfo leagueGame)
@@ -789,8 +754,6 @@ namespace SS.Matchmaking.Modules
 
         [ConfigHelp<bool>("SS.Matchmaking.TeamVersusMatch", "PublicPlayEnabled", ConfigScope.Arena, Default = false,
             Description = "Whether to allow players into ships without being in a match.")]
-        [ConfigHelp<bool>("SS.Matchmaking.TeamVersusMatch", "FilterKillPackets", ConfigScope.Arena, Default = false,
-            Description = "Whether to suppress kill notification packets for players assigned to a different match. Spectators (not assigned to any match) always receive all kill notifications.")]
         private void Callback_ArenaAction(Arena arena, ArenaAction action)
         {
             bool isRegisteredArena = false;
@@ -830,7 +793,6 @@ namespace SS.Matchmaking.Modules
                 }
 
                 arenaData.PublicPlayEnabled = _configManager.GetBool(ch, "SS.Matchmaking.TeamVersusMatch", "PublicPlayEnabled", false);
-                arenaData.FilterKillPackets = _configManager.GetBool(ch, "SS.Matchmaking.TeamVersusMatch", "FilterKillPackets", false);
 
                 // Register callbacks.
                 KillCallback.Register(arena, Callback_Kill);
@@ -7619,11 +7581,6 @@ namespace SS.Matchmaking.Modules
             public bool PublicPlayEnabled = false;
 
             /// <summary>
-            /// Whether kill notification packets are suppressed for players assigned to a different match.
-            /// </summary>
-            public bool FilterKillPackets = false;
-
-            /// <summary>
             /// A league match reserves control over the entire arena.
             /// </summary>
             public MatchData? LeagueMatch;
@@ -7636,7 +7593,6 @@ namespace SS.Matchmaking.Modules
                 ILeagueHelpToken = null;
                 Array.Clear(ShipSettings);
                 PublicPlayEnabled = false;
-                FilterKillPackets = false;
                 ReplayRecordingFilePath = null;
 
                 return true;


### PR DESCRIPTION
Bug: TeamVersusMatch registered IKillAdvisor at the broker level (broker.RegisterAdvisor<IKillAdvisor>(this)), but Game.cs queries it at the arena level (arena.GetAdvisors<IKillAdvisor>()). The advisor was never found, so FilterKillNotification never ran.