### PR TITLE
Fix/captains statbox stale rematch

### DIFF
--- a/src/Matchmaking/Modules/CaptainsMatch.cs
+++ b/src/Matchmaking/Modules/CaptainsMatch.cs
@@ -2754,13 +2754,18 @@ namespace SS.Matchmaking.Modules
         }
 
         /// <summary>
-        /// Returns the freq pair to use for a new challenge/accept. If one formation already holds an
-        /// assigned freq (winning team on field), returns that pair. Otherwise returns the first
-        /// pair not currently in use by any formation, countdown, or active match.
+        /// Returns the freq pair to use for a new challenge/accept. If one or both formations already
+        /// hold an assigned freq (winning team on field), returns the pair containing that freq.
+        /// When both formations have freqs from different pairs, the acceptor's pair takes priority
+        /// (the challenger comes to the acceptor). Otherwise returns the first pair not currently
+        /// in use by any formation, countdown, or active match.
         /// </summary>
         private static (short F1, short F2)? GetPairForChallenge(ArenaData arenaData, Formation formationA, Formation formationB)
         {
-            short? existingFreq = formationA.AssignedFreq ?? formationB.AssignedFreq;
+            // If both formations have assigned freqs, prefer the acceptor's (formationB) pair.
+            // The challenger gives up their old freq and moves to the acceptor's pair.
+            // If only one has an assigned freq, use that formation's pair.
+            short? existingFreq = formationB.AssignedFreq ?? formationA.AssignedFreq;
             if (existingFreq.HasValue)
             {
                 foreach (var pair in arenaData.Config.FreqPairs)
@@ -2783,16 +2788,22 @@ namespace SS.Matchmaking.Modules
 
         private static void AssignFreqs(ArenaData arenaData, Formation challenger, Formation acceptor, (short F1, short F2) pair)
         {
-            if (acceptor.AssignedFreq.HasValue)
+            bool IsInPair(short freq) => freq == pair.F1 || freq == pair.F2;
+            short OtherFreq(short freq) => freq == pair.F1 ? pair.F2 : pair.F1;
+
+            if (acceptor.AssignedFreq.HasValue && IsInPair(acceptor.AssignedFreq.Value))
             {
-                challenger.AssignedFreq = acceptor.AssignedFreq.Value == pair.F1 ? pair.F2 : pair.F1;
+                // Acceptor stays on their freq within the pair; challenger gets the other.
+                challenger.AssignedFreq = OtherFreq(acceptor.AssignedFreq.Value);
             }
-            else if (challenger.AssignedFreq.HasValue)
+            else if (challenger.AssignedFreq.HasValue && IsInPair(challenger.AssignedFreq.Value))
             {
-                acceptor.AssignedFreq = challenger.AssignedFreq.Value == pair.F1 ? pair.F2 : pair.F1;
+                // Challenger stays on their freq within the pair; acceptor gets the other.
+                acceptor.AssignedFreq = OtherFreq(challenger.AssignedFreq.Value);
             }
             else
             {
+                // Neither has a freq in this pair (or neither has an assigned freq at all).
                 challenger.AssignedFreq = pair.F1;
                 acceptor.AssignedFreq = pair.F2;
             }

--- a/src/Matchmaking/Modules/CaptainsMatch.cs
+++ b/src/Matchmaking/Modules/CaptainsMatch.cs
@@ -2361,7 +2361,8 @@ namespace SS.Matchmaking.Modules
 
             var config = new CaptainsMatchConfiguration(arenaData.Config);
             int pairIdx = arenaData.Config.FreqPairs.FindIndex(p => p.F1 == freq1 || p.F2 == freq1);
-            var matchData = new CaptainsMatchData(arena, config, (short)(pairIdx >= 0 ? pairIdx : 0));
+            int generation = arenaData.MatchGeneration++;
+            var matchData = new CaptainsMatchData(arena, config, (short)(pairIdx >= 0 ? pairIdx : 0), generation);
 
             var activeMatch = new ActiveMatch
             {
@@ -3003,10 +3004,18 @@ namespace SS.Matchmaking.Modules
 
             public AdvisorRegistrationToken<IFreqManagerEnforcerAdvisor>? FreqManagerEnforcerAdvisorToken;
 
+            /// <summary>
+            /// Monotonically increasing counter used to generate unique <see cref="MatchIdentifier"/>
+            /// values across consecutive matches on the same freq pair. Prevents the LVZ statbox
+            /// from displaying stale data due to client-side image caching when the identifier is reused.
+            /// </summary>
+            public int MatchGeneration;
+
             bool IResettable.TryReset()
             {
                 Arena = null!;
                 Config = null!;
+                MatchGeneration = 0;
                 Formations.Clear();
                 ActiveMatches.Clear();
                 PendingCountdowns.Clear();
@@ -3077,9 +3086,9 @@ namespace SS.Matchmaking.Modules
         {
             private ReadOnlyCollection<ITeam>? _teams;
 
-            public CaptainsMatchData(Arena arena, IMatchConfiguration configuration, short matchSlotId)
+            public CaptainsMatchData(Arena arena, IMatchConfiguration configuration, short matchSlotId, int generation)
             {
-                MatchIdentifier = new MatchIdentifier("CaptainsMatch", arena.Number, matchSlotId);
+                MatchIdentifier = new MatchIdentifier($"CaptainsMatch#{generation}", arena.Number, matchSlotId);
                 Configuration = configuration;
                 ArenaName = arena.Name;
                 Arena = arena;

--- a/src/Matchmaking/Modules/MatchLvz.cs
+++ b/src/Matchmaking/Modules/MatchLvz.cs
@@ -359,6 +359,18 @@ namespace SS.Matchmaking.Modules
             if (arena is null || !_arenaDataDictionary.TryGetValue(arena, out ArenaLvzData? arenaData))
                 return;
 
+            // Detach any players still assigned to a pre-existing state for this match identifier.
+            // This handles the case where a module (e.g. CaptainsMatch) reuses the same MatchIdentifier
+            // across consecutive matches on the same freq pair. Players may have been assigned during
+            // the countdown phase via MatchFocusChanged, and without detaching them first,
+            // SetAndSendMatchLvz would skip them (same state = no-op), leaving stale visuals.
+            foreach (StatboxPreference pref in new[] { StatboxPreference.Detailed, StatboxPreference.Simple, StatboxPreference.Off })
+            {
+                MatchLvzState? existingState = arenaData.TryGetMatch(matchData.MatchIdentifier, pref);
+                if (existingState is not null)
+                    RemovePlayers(existingState);
+            }
+
             // Gather all players watching this match and route them to their preferred state.
             // States are created lazily via SetAndSendMatchLvz.
             HashSet<Player> allPlayers = new();


### PR DESCRIPTION
# ADR-001: Captains Statbox + Cross-Pair Fix

## Status
Proposed

## Problem
Two issues found during captains playtesting:

**Stale statbox:** When the winning team stays on the field and a new challenger starts a rematch, players see the previous match's teams/stats in the statbox instead of the current match. Root cause is that CaptainsMatch reuses the same MatchIdentifier for consecutive matches on the same freq pair, and the client holds onto cached LVZ images from the previous match.

**Cross-pair blocking:** If winners from freq pair (100,200) challenge winners from pair (300,400), the match ends up on freqs 100 vs 300 — spanning both pairs. After that, no new matches can start because both pairs look occupied.

## Changes

**MatchLvz.cs** — In `Callback_TeamVersusMatchStarted`, clear out any players already assigned to the statbox state before re-sending it. Prevents the "already on this state, skip" shortcut from hiding updates. Doesn't affect TeamVersusMatch since it already uses unique identifiers.

**CaptainsMatch.cs** — Three things:
- Added a `MatchGeneration` counter to ArenaData. Each match gets a unique MatchType string like `CaptainsMatch#0`, `CaptainsMatch#1`, etc. This forces a fresh LVZ state with no client cache issues. BoxIdx stays as the pair index.
- Changed `GetPairForChallenge` to prefer the acceptor's pair when both teams have freqs from different pairs. The challenger gives up their old freq.
- Changed `AssignFreqs` to check that each team's freq is actually in the returned pair. If not, both get reassigned to the correct pair.

## What could break
- Stats JSON writes `box_number` (BoxIdx) which is unchanged. `MatchType` is not persisted, so the generation suffix has no database impact.
- The MatchLvz player detach runs for all modules, but it's a no-op when there's no pre-existing state (the normal case for TeamVersusMatch). Tested with queue-based 4v4pub matches — no regression.

## Testing done
- Multiple consecutive rematches on same freq pair — statbox correct every time
- Winners from different pairs challenging each other — challenger moved to acceptor's pair, other pair stays free
- Queue-based 4v4pub with groups — statbox and match formation unaffected
- Statbox simple/detailed toggle during matches — works in both arenas
