### PR TITLE
Fix disband/abort speccing players to match freq instead of spectator…

### DIFF
--- a/src/Matchmaking/Modules/CaptainsMatch.cs
+++ b/src/Matchmaking/Modules/CaptainsMatch.cs
@@ -2655,15 +2655,15 @@ namespace SS.Matchmaking.Modules
             countdown.Formation2.PairedWith = null;
             countdown.Formation2.AssignedFreq = null;
 
-            // Spec out all members of both formations — the pairing is broken and freq
-            // reservations are released, so players should not remain on those frequencies.
+            // Spec out all members of both formations to the spectator freq — the pairing is
+            // broken and freq reservations are released, so players should not remain on match freqs.
             foreach (Player p in countdown.Formation1.Members)
                 if (p.Ship != ShipType.Spec)
-                    _game.SetShipAndFreq(p, ShipType.Spec, p.Freq);
+                    _game.SetShipAndFreq(p, ShipType.Spec, arena.SpecFreq);
 
             foreach (Player p in countdown.Formation2.Members)
                 if (p.Ship != ShipType.Spec)
-                    _game.SetShipAndFreq(p, ShipType.Spec, p.Freq);
+                    _game.SetShipAndFreq(p, ShipType.Spec, arena.SpecFreq);
 
             SendToMatchAudience(arena, arenaData, countdown.ActiveMatch, reason);
         }
@@ -2686,11 +2686,11 @@ namespace SS.Matchmaking.Modules
                 }
             }
 
-            // Spec out all members.
+            // Spec out all members to the spectator freq so they don't remain on match freqs.
             foreach (Player p in formation.Members)
             {
                 if (p.Ship != ShipType.Spec)
-                    _game.SetShipAndFreq(p, ShipType.Spec, p.Freq);
+                    _game.SetShipAndFreq(p, ShipType.Spec, arena.SpecFreq);
                 if (p.TryGetExtraData(_pdKey, out PlayerData? pd))
                     pd.ManagedArena = null;
             }
@@ -2706,7 +2706,7 @@ namespace SS.Matchmaking.Modules
                 foreach (Player p in partner.Members)
                 {
                     if (p.Ship != ShipType.Spec)
-                        _game.SetShipAndFreq(p, ShipType.Spec, p.Freq);
+                        _game.SetShipAndFreq(p, ShipType.Spec, arena.SpecFreq);
                     if (p.TryGetExtraData(_pdKey, out PlayerData? pd))
                         pd.ManagedArena = null;
                 }


### PR DESCRIPTION
# ADR-002: Fix Disband/Abort Speccing Players to Match Freq

## Status
Proposed

## Problem
When a paired formation is disbanded or a countdown is aborted, players are specced using `p.Freq` (their current match freq) instead of `arena.SpecFreq`. This leaves them as spectators on match freqs like 100 or 200 instead of the spectator freq (8025).

When a new match later starts on that freq, the stranded spectators overlap with match participants.

Reproduced by: challenge → accept → disband (or: ready → cancel). Players end up on the match freq as spectators.

## Changes
Four `SetShipAndFreq` calls in `CaptainsMatch.cs` changed from `p.Freq` to `arena.SpecFreq`:
- Two in `AbortCountdown` (both formation member loops)
- Two in `DisbandFormation` (formation members + partner members)

This matches `EndMatch` which already uses `arena.SpecFreq`.

## What could break
Nothing — this only changes the target freq when speccing players during disband/abort. Players who are already on the spectator freq are unaffected (`p.Ship != ShipType.Spec` check skips them). No logic changes, just the freq parameter.

## Testing done
- Disband after accept (before ready): all 8 players → freq 8025
- Cancel during countdown: all 8 players → freq 8025
- Regression: statbox on rematch still correct, cross-pair challenge still works, match play unaffected
- Tested with both 2-player and 4-player team sizes