### PR TITLE
Fix players stuck after all teammates spec during countdown

### DIFF
--- a/src/Matchmaking/Modules/CaptainsMatch.cs
+++ b/src/Matchmaking/Modules/CaptainsMatch.cs
@@ -2648,6 +2648,9 @@ namespace SS.Matchmaking.Modules
             foreach (Player p in countdown.ActiveMatch.ActiveSlots.Keys)
                 arenaData.PlayerToMatch.Remove(p);
 
+            foreach (Player p in countdown.ActiveMatch.SpecOutSlots.Keys)
+                arenaData.PlayerToMatch.Remove(p);
+
             countdown.Formation1.IsReady = false;
             countdown.Formation1.PairedWith = null;
             countdown.Formation1.AssignedFreq = null;


### PR DESCRIPTION
# ADR-003: Fix Players Stuck After Speccing During Countdown

## Status
Proposed

## Problem
When all players on one team press spec during the 15-second countdown, they move from ActiveSlots to SpecOutSlots. The countdown aborts, but AbortCountdown only iterates ActiveSlots.Keys to remove players from PlayerToMatch. The specced players are orphaned — they get "You are already in an active match" when trying to ?cap or ?join afterward.

## Changes
One additional loop in `AbortCountdown` to also iterate `SpecOutSlots.Keys` when cleaning up `PlayerToMatch`. 3 lines added.

## Testing done
- All 4 players on one team spec during countdown → countdown aborts
- Specced players ?disband then ?cap → previously stuck with "already in active match", now works
- Regression: cancel, disband, statbox, cross-pair all still working
