### PR TITLE
Fix/captains setplaying integration

### DIFF
--- a/src/Matchmaking/Modules/CaptainsMatch.cs
+++ b/src/Matchmaking/Modules/CaptainsMatch.cs
@@ -1379,6 +1379,24 @@ namespace SS.Matchmaking.Modules
                 return;
             }
 
+            if (myFormation.Members.Count < arenaData.Config.PlayersPerTeam)
+            {
+                int needed = arenaData.Config.PlayersPerTeam - myFormation.Members.Count;
+                _chat.SendMessage(player, $"Cannot ready up — your team needs {needed} more player(s). ({myFormation.Members.Count}/{arenaData.Config.PlayersPerTeam})");
+
+                // Unpair both formations so the short team can recruit and the opponent can re-challenge.
+                Formation opponent = myFormation.PairedWith!;
+                myFormation.PairedWith = null;
+                myFormation.AssignedFreq = null;
+                myFormation.IsReady = false;
+                opponent.PairedWith = null;
+                opponent.AssignedFreq = null;
+                opponent.IsReady = false;
+
+                SendToAvailablePlayers(arena, arenaData, $"{player.Name}'s team lost a player — match pairing cancelled. Team is recruiting.");
+                return;
+            }
+
             if (myFormation.IsReady)
             {
                 _chat.SendMessage(player, "Your team is already marked as ready.");

--- a/src/Matchmaking/Modules/CaptainsMatch.cs
+++ b/src/Matchmaking/Modules/CaptainsMatch.cs
@@ -26,7 +26,7 @@ namespace SS.Matchmaking.Modules
     /// Supports multiple simultaneous matches when multiple freq pairs are configured.
     /// </summary>
     [ModuleInfo("Captain-based team formation with challenge system.")]
-    public sealed class CaptainsMatch : IModule, IArenaAttachableModule, IMatchFocusAdvisor, IFreqManagerEnforcerAdvisor
+    public sealed class CaptainsMatch : IModule, IArenaAttachableModule, IMatchFocusAdvisor, IFreqManagerEnforcerAdvisor, IPlayerGroupAdvisor
     {
         private readonly IChat _chat;
         private readonly ICommandManager _commandManager;
@@ -45,9 +45,12 @@ namespace SS.Matchmaking.Modules
         private IComponentBroker? _broker;
         private PlayerDataKey<PlayerData> _pdKey;
         private AdvisorRegistrationToken<IMatchFocusAdvisor>? _iMatchFocusAdvisorToken;
+        private AdvisorRegistrationToken<IPlayerGroupAdvisor>? _iPlayerGroupAdvisorToken;
 
         // optional
         private ITeamVersusStatsBehavior? _tvStatsBehavior;
+        private IMatchmakingQueues? _matchmakingQueues;
+        private IPlayerGroups? _playerGroups;
 
         private readonly Dictionary<Arena, ArenaData> _arenaDataDictionary = new(Constants.TargetArenaCount);
         private static readonly DefaultObjectPool<ArenaData> _arenaDataPool = new(new DefaultPooledObjectPolicy<ArenaData>(), Constants.TargetArenaCount);
@@ -80,15 +83,21 @@ namespace SS.Matchmaking.Modules
         {
             _broker = broker;
             _tvStatsBehavior = broker.GetInterface<ITeamVersusStatsBehavior>();
+            _matchmakingQueues = broker.GetInterface<IMatchmakingQueues>();
+            _playerGroups = broker.GetInterface<IPlayerGroups>();
             _pdKey = _playerData.AllocatePlayerData<PlayerData>();
             PlayerActionCallback.Register(broker, Callback_PlayerAction);
             _iMatchFocusAdvisorToken = broker.RegisterAdvisor<IMatchFocusAdvisor>(this);
+            _iPlayerGroupAdvisorToken = broker.RegisterAdvisor<IPlayerGroupAdvisor>(this);
             return true;
         }
 
         bool IModule.Unload(IComponentBroker broker)
         {
             if (!broker.UnregisterAdvisor(ref _iMatchFocusAdvisorToken))
+                return false;
+
+            if (!broker.UnregisterAdvisor(ref _iPlayerGroupAdvisorToken))
                 return false;
 
             _mainloop.WaitForMainWorkItemDrain();
@@ -98,6 +107,12 @@ namespace SS.Matchmaking.Modules
 
             if (_tvStatsBehavior is not null)
                 broker.ReleaseInterface(ref _tvStatsBehavior);
+
+            if (_matchmakingQueues is not null)
+                broker.ReleaseInterface(ref _matchmakingQueues);
+
+            if (_playerGroups is not null)
+                broker.ReleaseInterface(ref _playerGroups);
 
             _broker = null;
             return true;
@@ -554,6 +569,56 @@ namespace SS.Matchmaking.Modules
 
         #endregion
 
+        #region IPlayerGroupAdvisor
+
+        bool IPlayerGroupAdvisor.CanPlayerCreateGroup(Player player, StringBuilder message)
+        {
+            if (IsPlayerInCaptains(player))
+            {
+                message?.Append("Cannot create a group while in a captains team or match. Use ?ditch or ?disband first.");
+                return false;
+            }
+            return true;
+        }
+
+        bool IPlayerGroupAdvisor.CanPlayerBeInvited(Player player, StringBuilder message)
+        {
+            if (IsPlayerInCaptains(player))
+            {
+                message?.Append($"Cannot invite {player.Name} — they are in a captains team or match.");
+                return false;
+            }
+            return true;
+        }
+
+        bool IPlayerGroupAdvisor.CanPlayerAcceptInvite(Player player, StringBuilder message)
+        {
+            if (IsPlayerInCaptains(player))
+            {
+                message?.Append("Cannot accept a group invite while in a captains team or match. Use ?ditch or ?disband first.");
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if the player is in any captains formation or active/pending match.
+        /// </summary>
+        private bool IsPlayerInCaptains(Player player)
+        {
+            foreach (ArenaData arenaData in _arenaDataDictionary.Values)
+            {
+                if (GetPlayerFormation(arenaData, player) is not null)
+                    return true;
+
+                if (IsPlayerInMatch(arenaData, player))
+                    return true;
+            }
+            return false;
+        }
+
+        #endregion
+
         #region Callbacks
 
         private void Callback_PlayerAction(Player player, PlayerAction action, Arena? arena)
@@ -928,6 +993,12 @@ namespace SS.Matchmaking.Modules
                 return;
             }
 
+            if (_playerGroups?.GetGroup(player) is not null)
+            {
+                _chat.SendMessage(player, "You are in a group. Use ?group leave or ?group disband first.");
+                return;
+            }
+
             if (GetPlayerFormation(arenaData, player) is not null)
             {
                 _chat.SendMessage(player, "You are already in a team formation. Use ?ditch or ?disband to leave first.");
@@ -966,6 +1037,12 @@ namespace SS.Matchmaking.Modules
             if (player.Ship != ShipType.Spec)
             {
                 _chat.SendMessage(player, "You must be in spec to join a team.");
+                return;
+            }
+
+            if (_playerGroups?.GetGroup(player) is not null)
+            {
+                _chat.SendMessage(player, "You are in a group. Use ?group leave or ?group disband first.");
                 return;
             }
 
@@ -1993,6 +2070,27 @@ namespace SS.Matchmaking.Modules
         #region Helpers
 
         /// <summary>
+        /// Removes the Playing state from all players in a match (both active and specced out)
+        /// so they can queue for matchmaking again.
+        /// </summary>
+        private void UnsetPlayingForMatch(ActiveMatch match)
+        {
+            if (_matchmakingQueues is null)
+                return;
+
+            foreach (var (p, slot) in match.ActiveSlots)
+                _matchmakingQueues.UnsetPlaying(p, false);
+
+            foreach (var (p, slot) in match.SpecOutSlots)
+            {
+                if (slot.LeftArena)
+                    _matchmakingQueues.UnsetPlayingByName(slot.PlayerName!, false);
+                else
+                    _matchmakingQueues.UnsetPlaying(p, false);
+            }
+        }
+
+        /// <summary>
         /// Starts the abandon timer for <paramref name="freq"/> if it has no active players.
         /// Only fires when the match is active and <see cref="ArenaConfig.AbandonTimeoutMs"/> is non-zero.
         /// Safe to call unconditionally after any <see cref="ActiveMatch.ActiveSlots"/> removal.
@@ -2444,6 +2542,13 @@ namespace SS.Matchmaking.Modules
 
             matchData.SetTeams(team1, team2);
 
+            // Mark all participants as Playing to block ?next queueing during countdown and match.
+            if (_matchmakingQueues is not null)
+            {
+                foreach (Player p in activeMatch.ActiveSlots.Keys)
+                    _matchmakingQueues.SetPlaying(p);
+            }
+
             activeMatch.Freq1AbandonState = new AbandonState { Arena = arena, ArenaData = arenaData, Match = activeMatch, Freq = freq1 };
             activeMatch.Freq2AbandonState = new AbandonState { Arena = arena, ArenaData = arenaData, Match = activeMatch, Freq = freq2 };
 
@@ -2513,6 +2618,9 @@ namespace SS.Matchmaking.Modules
                 _ = _tvStatsBehavior.MatchEndedAsync(match.MatchData, MatchEndReason.Decided, winnerTeam);
 
             MatchEndedCallback.Fire(_broker!, match.MatchData);
+
+            // Remove Playing state so players can queue again after the match.
+            UnsetPlayingForMatch(match);
 
             // Remove from ActiveMatches before speccing players so that Callback_ShipFreqChange
             // does not fire spurious "has specced" announcements or re-schedule win-condition checks.
@@ -2652,6 +2760,9 @@ namespace SS.Matchmaking.Modules
 
             MatchEndedCallback.Fire(_broker!, match.MatchData);
 
+            // Remove Playing state so players can queue again after the match.
+            UnsetPlayingForMatch(match);
+
             // Remove from ActiveMatches before speccing players so that Callback_ShipFreqChange
             // does not fire spurious "has specced" announcements or re-schedule win-condition checks.
             arenaData.ActiveMatches.Remove(match);
@@ -2697,6 +2808,9 @@ namespace SS.Matchmaking.Modules
 
             foreach (Player p in countdown.ActiveMatch.SpecOutSlots.Keys)
                 arenaData.PlayerToMatch.Remove(p);
+
+            // Remove Playing state so players can queue again.
+            UnsetPlayingForMatch(countdown.ActiveMatch);
 
             countdown.Formation1.IsReady = false;
             countdown.Formation1.PairedWith = null;


### PR DESCRIPTION
# ADR-005: SetPlaying Integration and Group Isolation for Captains Matches

## Status
Proposed

## Problem
Players in a captains match could be queued into ?next matches (e.g. 4v4pub) because CaptainsMatch never called SetPlaying(). This was acknowledged as a TODO in IMatchmakingQueues.cs. During playtesting, a player in an active captains match was pulled into a ?next 4v4 match mid-game.

Additionally, there was no isolation between the group system and captains formations. A player in a group could ?captain or ?join a captains team, and a player in a captains formation could create or be invited to a group, leading to conflicting state.

## Changes

### 1. SetPlaying/UnsetPlaying lifecycle
CaptainsMatch now calls SetPlaying() for all participants when BuildMatchCountdown runs (both captains ?ready). This blocks ?next queueing during countdown and match. UnsetPlaying() is called in EndMatch, EndMatchDraw, and AbortCountdown.

Players in reformed formations (both winners and losers stay as formations after match end) are intentionally allowed to ?next between matches — the permissive approach mimics svs where a player in stack/cap arena could still .np while waiting.

### 2. Group isolation
Two-directional block:
- Command_Captain and Command_Join check IPlayerGroups.GetGroup() and block with a chat message if the player is in a group.
- CaptainsMatch implements IPlayerGroupAdvisor (CanPlayerCreateGroup, CanPlayerBeInvited, CanPlayerAcceptInvite) to block group operations for players in any captains formation or active match.

### 3. ?ready guard against incomplete formations
If a formation member gets pulled to another match between captains matches (via ?next), their HandlePlayerLeave removes them from the formation. When the captain tries ?ready with fewer than PlayersPerTeam members, the guard:
- Blocks readyup with a message showing the shortfall
- Auto-unpairs both formations (clears PairedWith, AssignedFreq, IsReady)
- Announces to the arena that the pairing is cancelled and the team is recruiting

This allows ?join and auto-join to fill the vacancy.

## Design decision: permissive vs. strict
Chose the permissive approach (allow ?next between matches) over strict (block ?next for all formation members). Rationale:
- SetPlaying during BuildMatchCountdown dequeues players from ?next, closing the race window once countdown starts
- The ?ready guard catches the case where a player is pulled before ?ready
- HandlePlayerLeave atomically removes pulled players from formations on the main loop thread, making Members.Count reliable
- Mimic svs functionality to allow .np while waiting for a stack/cap prac to form

## What could break
- IMatchmakingQueues and IPlayerGroups are resolved as optional interfaces. If either is not loaded, the corresponding feature degrades gracefully (no SetPlaying calls, no group checks).
- The IPlayerGroupAdvisor iterates all arenas via _arenaDataDictionary.Values in IsPlayerInCaptains(). This is O(arenas * formations + arenas * matches) per advisor call. Maybe negligible with typical arena counts.

## Testing done
- AJN-01 through AJN-03: Auto-join
- CND-01 through CND-02: Team spec abort countdown
- ISO-01: Player in captains match can't ?next (SetPlaying blocks)
- ISO-02: Player in captains countdown can't ?next
- ISO-03: Group member can't ?captain
- ISO-04: Group member can't ?join captains
- ISO-05: Captains player can't create group
- ISO-06: Captains player can't be invited to group
- ISO-07: After match ends, players can ?next again (UnsetPlaying)
- ISO-08: ?ready blocked when team is short, auto-unpair fires
- ISO-09: Free player can ?join and auto-join the short team after unpair
- ISO-10: SetPlaying during countdown dequeues formation member from ?next
- REG-01 through REG-08: Full regression suite passes (PM join, full match, winner rematch, disband to spec freq, cancel to spec freq, kick cooldown, disband doesn't affect ongoing match, cancel doesn't affect ongoing match)
- SBX-01 through SBX-02: Statbox and Freq Pairing
