### PR TITLE
Allow spectators to join match freqs for team comms

### DIFF
--- a/src/Matchmaking/Modules/CaptainsMatch.cs
+++ b/src/Matchmaking/Modules/CaptainsMatch.cs
@@ -484,7 +484,11 @@ namespace SS.Matchmaking.Modules
 
             bool isMatchFreq = arenaData.Config.FreqPairs.Any(p => p.F1 == newFreq || p.F2 == newFreq);
             if (!isMatchFreq)
-                return true; // Spectator freqs are freely allowed.
+                return true; // Non-match freqs are freely allowed.
+
+            // Allow spectators to join match freqs for team comms.
+            if (player.Ship == ShipType.Spec)
+                return true;
 
             // It is a match freq — player must be assigned to it.
             if (arenaData.PlayerToMatch.TryGetValue(player, out ActiveMatch? match))


### PR DESCRIPTION
# ADR-006: Spectator Freq Access for Team Comms in Captains Arenas

## Status
Proposed

## Problem
Spectators in captains arenas can't join match freqs (100, 200, 300, 400). They get "You are not assigned to that freq." This blocks non-playing members from using team chat for the given freqs.

## Changes
One check added to `CaptainsMatch.CanChangeToFreq`: if the player is in spec, allow them to join any match freq. `CanEnterGame` separately prevents spectators from entering a ship on a match freq they aren't assigned to, so they can only observe and chat.

## Design decision: open access
Any spectator can join any match freq, including the opposing team's. This matches how spectators typically work in svs — they can freely change freqs.

A specced-out match player (in SpecOutSlots) also passes this check, meaning they could switch to the opponent's freq to read team chat.

## Config requirement
Arena configs that inherit from svs-league set `MaxPerPrivateTeam=0`, which causes FreqManager to block all private freq changes independently. Arenas using captains with private freq pairs (100+) need `MaxPerPrivateTeam` set to a positive value (e.g., 10) for this feature to work.

## What could break
Nothing. The check runs before the existing match/formation checks. Players already in a match or formation hit the existing logic paths. Spectators who join a match freq and then try to enter a ship get "You are not on a team" from `CanEnterGame`.

## Testing done
- Spectator joins match freq during active match — allowed
- Spectator on match freq enters ship — blocked ("You are not on a team")
- Spectator switches between match freqs (100 → 200) — allowed
- Player specs to match freq, then ?cap + ?join flow, enters ship — placed on correct assigned freq (not the freq they were spectating on)
- No regression tests were performed
