### PR TITLE
Add Nexus rank command

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusStats.cs
+++ b/src/Matchmaking/Modules/TeamVersusStats.cs
@@ -293,6 +293,7 @@ namespace SS.Matchmaking.Modules
 
             _commandManager.AddCommand(CommandNames.Chart, Command_chart, arena);
             _commandManager.AddCommand(CommandNames.ChartHelp, Command_charthelp, arena);
+            _commandManager.AddCommand(CommandNames.Rank, Command_rank, arena);
 
             arenaData.ILeagueHelpToken = arena.RegisterInterface<ILeagueHelp>(this, nameof(TeamVersusStats));
 
@@ -316,6 +317,7 @@ namespace SS.Matchmaking.Modules
 
             _commandManager.RemoveCommand(CommandNames.Chart, Command_chart, arena);
             _commandManager.RemoveCommand(CommandNames.ChartHelp, Command_charthelp, arena);
+            _commandManager.RemoveCommand(CommandNames.Rank, Command_rank, arena);
 
             TeamVersusMatchPlayerLagOutCallback.Unregister(arena, Callback_TeamVersusMatchPlayerLagOut);
             TeamVersusMatchPlayerShipChangedCallback.Unregister(arena, Callback_TeamVersusMatchPlayerShipChanged);
@@ -2887,6 +2889,88 @@ namespace SS.Matchmaking.Modules
             _chat.SendMessage(player, "^ Accounts for active utility drain: Stealth, Cloak, X-Radar, and Anti-Warp.");
         }
 
+        [CommandHelp(
+            Args = "[player]",
+            Description = "Prints a player's Nexus Rank for the currently focused TeamVersus match type.")]
+        private void Command_rank(ReadOnlySpan<char> commandName, ReadOnlySpan<char> parameters, Player player, ITarget target)
+        {
+            string? targetPlayerName = parameters.IsWhiteSpace()
+                ? player.Name
+                : parameters.Trim().ToString();
+
+            if (string.IsNullOrWhiteSpace(targetPlayerName))
+            {
+                _chat.SendMessage(player, "Nexus Rank: Unrated");
+                return;
+            }
+
+            _ = CommandRankAsync(player, targetPlayerName);
+        }
+
+        private async Task CommandRankAsync(Player player, string targetPlayerName)
+        {
+            try
+            {
+                IMatch? match = _matchFocus.GetFocusedMatch(player);
+                if (match is not IMatchData matchData || matchData.Configuration.GameTypeId is not long gameTypeId)
+                {
+                    _chat.SendMessage(player, "Nexus Rank is unavailable here. Join or spectate a TeamVersus match and try again.");
+                    return;
+                }
+
+                IMatchConfiguration matchConfiguration = matchData.Configuration;
+                PlayerRating? rating = null;
+                Dictionary<string, PlayerRating> ratings = _playerRatingDictionaryPool.Get();
+
+                try
+                {
+                    ratings[targetPlayerName] = new PlayerRating
+                    {
+                        PlayerName = targetPlayerName,
+                        Mu = matchConfiguration.OpenSkillModel.Mu,
+                        Sigma = matchConfiguration.OpenSkillModel.Sigma,
+                    };
+
+                    if (_gameStatsRepository is not null)
+                    {
+                        await _gameStatsRepository.GetPlayerOpenSkillRatingsAsync(gameTypeId, ratings);
+                    }
+
+                    if (ratings.TryGetValue(targetPlayerName, out PlayerRating? foundRating)
+                        && foundRating.LastUpdated is not null)
+                    {
+                        AdjustOpenSkillRatingsForDecay(matchConfiguration, ratings, DateTime.UtcNow);
+                        rating = foundRating;
+                    }
+                }
+                catch
+                {
+                    rating = null;
+                }
+                finally
+                {
+                    _playerRatingDictionaryPool.Return(ratings);
+                }
+
+                if (rating is null)
+                {
+                    _chat.SendMessage(player, $"Nexus Rank: {targetPlayerName} — Unrated");
+                    return;
+                }
+
+                double visibleRank = Math.Floor(rating.GetOrdinal(
+                    z: matchConfiguration.OpenSkillDisplayOrdinal.Z,
+                    alpha: matchConfiguration.OpenSkillDisplayOrdinal.Alpha,
+                    target: matchConfiguration.OpenSkillDisplayOrdinal.Target));
+
+                _chat.SendMessage(player, $"Nexus Rank: {targetPlayerName} — {visibleRank:F0}");
+            }
+            catch
+            {
+                _chat.SendMessage(player, $"Nexus Rank: {targetPlayerName} — Unrated");
+            }
+        }
+
         #endregion
 
         private static void AddOrUpdatePlayerInfo(MatchStats matchStats, string playerName, Player? player)
@@ -4706,6 +4790,7 @@ namespace SS.Matchmaking.Modules
         {
             public const string Chart = "chart";
             public const string ChartHelp = "charthelp";
+            public const string Rank = "rank";
         }
 
         #endregion


### PR DESCRIPTION
## Summary

Adds a minimal `?rank` command for TeamVersus/NEXUS rank lookup.

The command displays a public player-facing Nexus Rank using existing OpenSkill rating data and the current focused TeamVersus match configuration.

## Behavior

- `?rank` shows the caller's rank
- `?rank <player>` shows a rank lookup by player name
- Works from focused TeamVersus match context
- If no focused TeamVersus match/config is available, returns a clean unavailable message
- If no rating exists or lookup fails, returns Unrated

## Scope

- Only touches `TeamVersusStats.cs`
- No queue changes
- No matchmaking changes
- No database/schema changes
- No rating update changes
- No leaderboard/monthly system changes
- Does not expose raw OpenSkill `mu` or `sigma`

## Verification

Built successfully with:

```bash
dotnet build src\SubspaceServer.slnx