### PR TITLE
Broadcast repels twice to mitigate repignore chance

### DIFF
--- a/src/Core/Modules/Game.cs
+++ b/src/Core/Modules/Game.cs
@@ -753,6 +753,8 @@ namespace SS.Core.Modules
             Description = "How far away to to send positions of players on radar (in pixels).")]
         [ConfigHelp<int>("Net", "AntiwarpSendPercent", ConfigScope.Arena, Default = 5,
             Description = "Percent of position packets with antiwarp enabled to send to the whole arena.")]
+        [ConfigHelp<bool>("Net", "SendRepelTwice", ConfigScope.Arena, Default = false,
+            Description = "Whether to send each repel weapon packet twice (unreliable) for redundancy. Repels are gameplay-critical and otherwise vulnerable to UDP packet loss. The duplicate is sent with the Urgent flag so it bypasses the grouper and lands in its own UDP datagram.")]
         // Note: Toggle:AntiwarpPixels is a client setting, so its [ConfigHelp] is in ClientSettingsConfig.cs
         // Note: Kill:EnterDelay is a client setting, so its [ConfigHelp] is in ClientSettingsConfig.cs
         private void Callback_ArenaAction(Arena arena, ArenaAction action)
@@ -808,6 +810,8 @@ namespace SS.Core.Modules
 
                 ad.SendAnti = _configManager.GetInt(ch, "Net", "AntiwarpSendPercent", ArenaSettings.Net.AntiwarpSendPercent.Default);
                 ad.SendAnti = Constants.RandMax / 100 * ad.SendAnti;
+
+                ad.SendRepelTwice = _configManager.GetBool(ch, "Net", "SendRepelTwice", ArenaSettings.Net.SendRepelTwice.Default);
 
                 int cfg_AntiwarpPixels = _configManager.GetInt(ch, "Toggle", "AntiwarpPixels", 1);
                 ad.AntiWarpRange = cfg_AntiwarpPixels * cfg_AntiwarpPixels;
@@ -1607,6 +1611,16 @@ namespace SS.Core.Modules
                                             data = data[..length];
 
                                         _network.SendToOne(otherPlayer, data, sendFlags);
+
+                                        // Repels are gameplay-critical; resend unreliably for redundancy.
+                                        // The Urgent flag forces the duplicate down SendOrBufferPacket's fast path (SendRaw), so it
+                                        // lands in its own UDP datagram rather than being coalesced with the original into a 0x00 0x0E
+                                        // grouped packet. That gives the duplicate independent fate against per-datagram wire loss.
+                                        // Don't increment the lag-stat weapon-sent counter again — this is one logical weapon event.
+                                        if (posCopy.Weapon.Type == WeaponCodes.Repel && arenaData.SendRepelTwice)
+                                        {
+                                            _network.SendToOne(otherPlayer, data, sendFlags | NetSendFlags.Urgent);
+                                        }
                                     }
                                     else
                                     {
@@ -2995,6 +3009,11 @@ namespace SS.Core.Modules
             public int SendAnti;
 
             /// <summary>
+            /// Whether to send each repel weapon packet twice (unreliable) for redundancy.
+            /// </summary>
+            public bool SendRepelTwice;
+
+            /// <summary>
             /// Distance anti-warp affects other players (in pixels).
             /// </summary>
             public int AntiWarpRange;
@@ -3029,6 +3048,7 @@ namespace SS.Core.Modules
                 FastBombingThreshold = 0;
                 PositionPixels = 0;
                 SendAnti = 0;
+                SendRepelTwice = false;
                 AntiWarpRange = 0;
                 EnterDelay = 0;
                 Array.Clear(WeaponRange);

--- a/src/Core/Modules/Game.cs
+++ b/src/Core/Modules/Game.cs
@@ -754,7 +754,7 @@ namespace SS.Core.Modules
         [ConfigHelp<int>("Net", "AntiwarpSendPercent", ConfigScope.Arena, Default = 5,
             Description = "Percent of position packets with antiwarp enabled to send to the whole arena.")]
         [ConfigHelp<bool>("Net", "SendRepelTwice", ConfigScope.Arena, Default = false,
-            Description = "Whether to send each repel weapon packet twice (unreliable) for redundancy. Repels are gameplay-critical and otherwise vulnerable to UDP packet loss. The duplicate is sent with the Urgent flag so it bypasses the grouper and lands in its own UDP datagram.")]
+            Description = "Whether to send each repel weapon packet twice (unreliable) for redundancy. Repels are gameplay-critical and otherwise vulnerable to UDP packet loss.")]
         // Note: Toggle:AntiwarpPixels is a client setting, so its [ConfigHelp] is in ClientSettingsConfig.cs
         // Note: Kill:EnterDelay is a client setting, so its [ConfigHelp] is in ClientSettingsConfig.cs
         private void Callback_ArenaAction(Arena arena, ArenaAction action)
@@ -1613,13 +1613,14 @@ namespace SS.Core.Modules
                                         _network.SendToOne(otherPlayer, data, sendFlags);
 
                                         // Repels are gameplay-critical; resend unreliably for redundancy.
-                                        // The Urgent flag forces the duplicate down SendOrBufferPacket's fast path (SendRaw), so it
-                                        // lands in its own UDP datagram rather than being coalesced with the original into a 0x00 0x0E
-                                        // grouped packet. That gives the duplicate independent fate against per-datagram wire loss.
+                                        // Both sends use sendFlags (which contains PriorityP5 → Urgent bit), so each goes out
+                                        // via SendRaw as its own UDP datagram. The two datagrams have independent fate against
+                                        // single-packet wire loss, though they're sent microseconds apart so correlated burst
+                                        // loss (router queue overflow, Wi-Fi retry window) can still take both.
                                         // Don't increment the lag-stat weapon-sent counter again — this is one logical weapon event.
                                         if (posCopy.Weapon.Type == WeaponCodes.Repel && arenaData.SendRepelTwice)
                                         {
-                                            _network.SendToOne(otherPlayer, data, sendFlags | NetSendFlags.Urgent);
+                                            _network.SendToOne(otherPlayer, data, sendFlags);
                                         }
                                     }
                                     else


### PR DESCRIPTION
I've been observing a suspicious amount of rep ignores in nexus gameplay. 

This change adds a flag (set at the arena level) to decrease the chance of a rep being dropped by a client -- we broadcast the packet twice for redundancies sake. e.g. If a client has 0.5% S2C packet loss, this will hopefully make it go from a 1 out of 200 chance of dropping the rep to 1 out of 40,000.