### PR TITLE
Add s2c avg latency from position packets

### DIFF
--- a/src/Core/ComponentInterfaces/ILagCollect.cs
+++ b/src/Core/ComponentInterfaces/ILagCollect.cs
@@ -10,7 +10,7 @@
         public readonly uint S2CFastTotal { get; init; }
         public readonly ushort S2CSlowCurrent { get; init; }
         public readonly ushort S2CFastCurrent { get; init; }
-        public readonly ushort Unknown1 { get; init; }
+        public readonly ushort S2CAverageCurrent { get; init; }
         public readonly ushort LastPing { get; init; }
         public readonly ushort AveragePing { get; init; }
         public readonly ushort LowestPing { get; init; }

--- a/src/Core/ComponentInterfaces/ILagQuery.cs
+++ b/src/Core/ComponentInterfaces/ILagQuery.cs
@@ -11,7 +11,7 @@ namespace SS.Core.ComponentInterfaces
     {
         public int Current, Average, Min, Max;
         public uint S2CSlowTotal, S2CFastTotal;
-        public ushort S2CSlowCurrent, S2CFastCurrent;
+        public ushort S2CSlowCurrent, S2CFastCurrent, S2CAverageCurrent;
     }
 
     public struct PacketlossSummary

--- a/src/Core/Modules/LagData.cs
+++ b/src/Core/Modules/LagData.cs
@@ -501,6 +501,7 @@ namespace SS.Core.Modules
                     ping.S2CFastTotal = ClientReportedData.S2CFastTotal;
                     ping.S2CSlowCurrent = ClientReportedData.S2CSlowCurrent;
                     ping.S2CFastCurrent = ClientReportedData.S2CFastCurrent;
+                    ping.S2CAverageCurrent = ClientReportedData.S2CAverageCurrent;
                 }
             }
 

--- a/src/Core/Modules/PlayerCommand.cs
+++ b/src/Core/Modules/PlayerCommand.cs
@@ -584,7 +584,7 @@ namespace SS.Core.Modules
                 double s2cRelLoss = (reliableLag.Retries == 0) ? 0d : ((reliableLag.Retries - reliableLag.AckDups) * 100d / reliableLag.ReliablePacketsSent);
                 _chat.SendMessage(player, $"{prefix}: ploss: s2c: {packetloss.S2C * 100d:F2}  c2s: {packetloss.C2S * 100d:F2}  s2cwpn: {packetloss.S2CWeapon * 100d:F2}  s2crel: {s2cRelLoss:F2}");
                 _chat.SendMessage(player, $"{prefix}: reliable: dups: {reliableLag.RelDups * 100d / reliableLag.ReliablePacketsReceived:F2}%  resends: {reliableLag.Retries * 100d / reliableLag.ReliablePacketsSent:F2}%");
-                _chat.SendMessage(player, $"{prefix}: s2c slow: {clientPing.S2CSlowCurrent}/{clientPing.S2CSlowTotal}  s2c fast: {clientPing.S2CFastCurrent}/{clientPing.S2CFastTotal}");
+                _chat.SendMessage(player, $"{prefix}: s2c slow: {clientPing.S2CSlowCurrent}/{clientPing.S2CSlowTotal}  s2c fast: {clientPing.S2CFastCurrent}/{clientPing.S2CFastTotal} s2c avg: {clientPing.S2CAverageCurrent * 10}");
 
                 PrintCommonBandwidthInfo(player, targetPlayer, DateTime.UtcNow - targetPlayer.ConnectTime, prefix, false);
             }

--- a/src/Core/Modules/Security.cs
+++ b/src/Core/Modules/Security.cs
@@ -686,7 +686,7 @@ namespace SS.Core.Modules
                 S2CFastTotal = pkt.S2CFastTotal,
                 S2CSlowCurrent = pkt.S2CSlowCurrent,
                 S2CFastCurrent = pkt.S2CFastCurrent,
-                Unknown1 = pkt.Unknown1,
+                S2CAverageCurrent = pkt.S2CAverageCurrent,
                 LastPing = pkt.LastPing,
                 AveragePing = pkt.AveragePing,
                 LowestPing = pkt.LowestPing,

--- a/src/Packets/Game/Security.cs
+++ b/src/Packets/Game/Security.cs
@@ -34,7 +34,7 @@ namespace SS.Packets.Game
         private uint s2CFastTotal;
         private ushort s2CSlowCurrent;
         private ushort s2CFastCurrent;
-        private ushort unknown1;
+        private ushort s2CAverageCurrent;
         private ushort lastPing;
         private ushort averagePing;
         private ushort lowestPing;
@@ -92,10 +92,10 @@ namespace SS.Packets.Game
             set => s2CFastCurrent = LittleEndianConverter.Convert(value);
         }
 
-        public ushort Unknown1
+        public ushort S2CAverageCurrent
         {
-            readonly get => LittleEndianConverter.Convert(unknown1);
-            set => unknown1 = LittleEndianConverter.Convert(value);
+            readonly get => LittleEndianConverter.Convert(s2CAverageCurrent);
+            set => s2CAverageCurrent = LittleEndianConverter.Convert(value);
         }
 
         public ushort LastPing


### PR DESCRIPTION
- Update security packet to replace the unknown field.
- Adjust lag -v output to include the average value.