### PR TITLE
Fix TeamVersus match slot participation not being tracked for unused slots

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -2290,6 +2290,9 @@ namespace SS.Matchmaking.Modules
                     AssignSlot(slot, player);
                     slot.Status = PlayerSlotStatus.Playing;
 
+                    // Track the player's participation so the slot dictionary entry gets cleaned up when the match ends.
+                    leagueMatch.ParticipationList.Add(new PlayerParticipationRecord(player.Name!, false, false));
+
                     // Put the player in with a full ship of their choice.
                     SetShipAndFreq(slot, false, null, ItemsAction.Full);
 


### PR DESCRIPTION
## Summary
- When a player is assigned to a slot in a Team Versus match, a `PlayerParticipationRecord` is now added so the slot's dictionary entry is properly cleaned up when the match ends, fixing a leak of unused slots.

## Test plan
- [ ] Manually verify a Team Versus match completes and slot state is cleaned up with no leaked entries.