### PR TITLE
Fix TeamVersus incorrectly redirecting subbed-out players back to their old match

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -981,15 +981,14 @@ namespace SS.Matchmaking.Modules
                     // The player connected and entered an arena.
                     playerData.IsInitialConnect = false;
 
-                    if (_playerSlotDictionary.TryGetValue(player.Name!, out PlayerSlot? playerSlot))
+                    if (_playerSlotDictionary.TryGetValue(player.Name!, out PlayerSlot? playerSlot)
+                        && string.Equals(playerSlot.PlayerName, player.Name, StringComparison.OrdinalIgnoreCase))
                     {
-                        // The player is associated with an ongoing match.
-                        if (string.Equals(playerSlot.PlayerName, player.Name, StringComparison.OrdinalIgnoreCase))
-                        {
-                            // The player is still assigned to the slot.
-                            playerData.AssignedSlot = playerSlot;
-                            playerSlot.Player = player;
-                        }
+                        // The player is still assigned to the slot of an ongoing match.
+                        // Note: the dictionary entry can be stale (e.g. the player was subbed out) until the match ends,
+                        // so it's important to check that the slot is still assigned to this player before acting on it.
+                        playerData.AssignedSlot = playerSlot;
+                        playerSlot.Player = player;
 
                         if (!string.Equals(arena!.Name, playerSlot.MatchData.ArenaName, StringComparison.OrdinalIgnoreCase))
                         {


### PR DESCRIPTION
## Summary
- The player-name-to-slot dictionary used to look up a player's ongoing match keeps a stale entry for a player after they've been subbed out (it is only cleaned up when the whole match ends).
- In `Callback_PlayerAction` (`PlayerAction.EnterGame`), this stale entry was used unconditionally: a subbed-out player who reconnects/enters the game while their old match is still in progress would get force-redirected to that match's arena and re-attached to the slot, even though the slot now belongs to a different player.
- The fix gates the redirect/reassignment on the slot still actually being assigned to that player (`playerSlot.PlayerName == player.Name`), matching the check already used elsewhere in the same method.

## Test plan
- [ ] In a Team Versus match, have a player get subbed out, then have that same player disconnect and reconnect while the match is still in progress -- verify they are NOT forced back into the old match's arena/slot.
- [ ] Verify a player who is still legitimately assigned to a slot (e.g. reconnecting after a lagout) is still correctly redirected to their match's arena as before.