### PR TITLE
Fix division by zero in TeamVersus assist rating calculation

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusStats.cs
+++ b/src/Matchmaking/Modules/TeamVersusStats.cs
@@ -1352,7 +1352,7 @@ namespace SS.Matchmaking.Modules
                             continue;
 
                         attackerMemberStats.RatingChange += ratingChangeDictionary[attacker.PlayerName] =
-                            assistPoints * ((float)killedMemberStats.TeamStats.RemainingSlots / Math.Min(1, attackerTeamStats.RemainingSlots));
+                            assistPoints * ((float)killedMemberStats.TeamStats.RemainingSlots / Math.Max(1, attackerTeamStats.RemainingSlots));
                     }
                 }
 


### PR DESCRIPTION
## Summary
- When crediting an assist for a kill, the attacker's remaining team slot count was floored using Math.Min(1, attackerTeamStats.RemainingSlots) instead of Math.Max(1, attackerTeamStats.RemainingSlots).
- Once an attacker's own team had already been fully knocked out (0 remaining slots) by the time a delayed kill/damage event was processed (kill processing is intentionally delayed via PlayerKillDamageStatsDelayMs to let final damage packets arrive), Math.Min(1, 0) evaluates to 0, making the divisor 0. Dividing a positive value by 0 in floating point yields Infinity.
- (int)float.PositiveInfinity in C# produces int.MaxValue (2147483647). That value gets written into the game JSON as rating_change, and PostgreSQL rejects it with 22003: integer out of range when ss.save_game tries to insert it into an integer column -- causing the match's stats to fail to save.

## Root cause confirmation
Reproduced from an actual failed-save JSON dump (SaveGameFallbackFolderPath) where team freq 200 hit remaining_slots: 0, and the very next (team-kill) event still credited a player from that already-eliminated team as an assist attacker with "rating_change":2147483647.

## Fix
Changed Math.Min to Math.Max so the divisor is floored at a minimum of 1 instead of capped at a maximum of 1, matching the evident intent (avoid divide-by-zero, not artificially shrink the denominator).

## Test plan
- [ ] Play/simulate a Team Versus match where one team is fully knocked out and a delayed damage/kill event still attributes an assist to a member of that eliminated team; verify the rating change is a normal finite value and the game saves to the database successfully.