### PR TITLE
Fix TeamVersus not clearing the inactive-slot timer on match end

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -6969,6 +6969,10 @@ namespace SS.Matchmaking.Modules
                         _game.SetShipAndFreq(slot.Player, ShipType.Spec, arena.SpecFreq);
                     }
 
+                    // Cancel any pending inactive slot timer so that it can't later fire against
+                    // this slot after it's been reassigned to a different player in a future match.
+                    _mainloopTimer.ClearTimer<PlayerSlot>(MainloopTimer_ProcessInactiveSlot, slot);
+
                     UnassignSlot(slot, false);
                 }
             }


### PR DESCRIPTION
## Summary
- Matchmaking matches reuse the same MatchData/Team/PlayerSlot objects for the next match hosted in the same box (only league matches discard MatchData at match end).
- When a slot went inactive (lag out / changed to spec) during a match, a one-shot MainloopTimer_ProcessInactiveSlot timer is scheduled for that PlayerSlot (TeamVersusMatch.cs:5542). It is only ever cancelled in SetShipAndFreq (when the player returns or someone subs in) -- EndMatch never cancels it.
- If the match ends or is cancelled while that timer is still pending (e.g. a player lagged out near the end of the match and never returned), the timer survives match end. Since matchmaking immediately reuses the same PlayerSlot object for the next match in that box, and slots legitimately sit in PlayerSlotStatus.Waiting early in a new match, the stale timer's guard (`if (slot.Status != Waiting) return false;`) can pass against a completely different player's slot in the *new* match.
- When that happens, the stale timer incorrectly marks the new match's slot available for ?sub and sends a "has left the arena" notification for a player who never left, purely because of leftover state from a previous, unrelated match.

## Fix
EndMatch's per-slot cleanup loop now explicitly clears any pending MainloopTimer_ProcessInactiveSlot timer for each slot before the slot (and MatchData) is reset/reused.

## Test plan
- [ ] Start a matchmaking match, have a player lag out (leave the arena or change to spec) without returning, then end/cancel the match before the InactiveSlotAvailableDelay elapses. Start a new match in the same box and verify no bogus "has left the arena"/sub-availability notification appears for the new occupant of that slot.