### PR TITLE
Fix TeamVersus not clearing match completion check timers on match end

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -6813,6 +6813,11 @@ namespace SS.Matchmaking.Modules
             // Change the status to stop any additional attempts to end the match while we're ending it.
             matchData.Status = MatchStatus.Complete;
 
+            // Cancel any pending match completion check timers so that they can't later fire
+            // against this MatchData after it's been reset/reused for a future match.
+            _mainloopTimer.ClearTimer<MatchData>(MainloopTimer_WinConditionCheckForMatchCompletion, matchData);
+            _mainloopTimer.ClearTimer<MatchData>(MainlooopTimer_CheckForMatchCompletion, matchData);
+
             MatchEndingCallback.Fire(_broker, matchData);
 
             bool isNotificationHandled = false;


### PR DESCRIPTION
## Summary
- Matchmaking matches reuse the same MatchData object for the next match hosted in the same box (only league matches discard MatchData at match end).
- ScheduleWinConditionCheckForMatchCompletion and ScheduleCheckForMatchCompletion (TeamVersusMatch.cs:6699-6716) schedule one-shot timers keyed by MatchData that call CheckForMatchCompletion. EndMatch never cancelled either of these pending timers.
- If a match ended (e.g. by time limit / draw) or was cancelled while one of these was still pending (e.g. a kill just happened and the short win-condition delay hadn't elapsed yet, or a team had just gone inactive and the inactive-teams completion delay was still running), the timer would survive match end.
- Since matchmaking immediately resets and reuses the same MatchData object for a new match in that box, the stale timer would later fire CheckForMatchCompletion against the *new* match's live state -- a redundant/unintended completion check that happens to be guarded by `Status == InProgress` (so it can't corrupt an inactive match), but is still incorrect leftover state from a previous, unrelated match acting on a new one.

## Fix
EndMatch now explicitly clears both MainloopTimer_WinConditionCheckForMatchCompletion and MainlooopTimer_CheckForMatchCompletion for the MatchData as soon as the match starts ending, before any further cleanup/reset happens.

## Test plan
- [ ] Trigger a kill (scheduling the win-condition check) or an inactive-team scenario (scheduling the completion check) and immediately end/cancel the match via another path (e.g. time limit) before the scheduled delay elapses. Start a new match in the same box and verify no spurious completion check/log occurs against the new match shortly after it starts.