### PR TITLE
Fix TeamVersus leaking available-sub-slot entries on league match end

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -6969,6 +6969,14 @@ namespace SS.Matchmaking.Modules
                         _game.SetShipAndFreq(slot.Player, ShipType.Spec, arena.SpecFreq);
                     }
 
+                    // Remove the slot from the available-to-sub list, if it's in it.
+                    // This is normally done by PlayerSlot.Reset(), but league matches don't reset/reuse
+                    // their MatchData (a new one is created for the next match), so without this the
+                    // node would remain linked into _availableSubSlots indefinitely, keeping this now-ended
+                    // match's Team/PlayerSlot/MatchData objects alive and reachable via ?sub.
+                    slot.AvailableSubSlotNode.List?.Remove(slot.AvailableSubSlotNode);
+                    slot.IsSubRequested = false;
+
                     UnassignSlot(slot, false);
                 }
             }


### PR DESCRIPTION
## Summary
- PlayerSlot.Reset() removes a slot's AvailableSubSlotNode from the module-level _availableSubSlots linked list and clears IsSubRequested, but Reset() is only invoked via MatchData.Reset() -- which happens for matchmaking matches (the MatchData/Team/PlayerSlot objects are reused for the next match hosted in the same box).
- League matches never call MatchData.Reset(): EndMatch explicitly removes the MatchData from _matchDataDictionary and returns instead, since a brand new MatchData is created for each league match (see ILeagueGameMode.CreateMatch).
- Consequence: if a league match ended or was cancelled while one of its slots was linked into _availableSubSlots (e.g. a captain used ?requestsub on a slot, or a slot lagged out long enough to become sub-available), that slot's node was never unlinked from the list. This keeps the ended match's Team/PlayerSlot/MatchData object graph alive and reachable indefinitely (a leak), and -- for any match type configuration that is both LeagueEnabled and has a Queue configured -- could let ?sub's solo-queue path (which iterates _availableSubSlots directly) match a solo player into a slot belonging to an already-ended match.

## Fix
EndMatch's per-slot cleanup loop now explicitly removes each slot's AvailableSubSlotNode from _availableSubSlots and clears IsSubRequested, for all match types (not just implicitly via the matchmaking-only Reset() path).

## Test plan
- [ ] In a league match, use ?requestsub (or let a slot lag out past the inactive-slot delay) so the slot is linked into the available-sub-slot list, then end/cancel the match. Verify the slot is no longer considered available for a solo ?sub afterward and the old match's objects aren't retained.