### PR TITLE
Fix TeamVersus not clearing the knockout-processing timer on match end

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -1376,17 +1376,16 @@ namespace SS.Matchmaking.Modules
                     _objectPoolManager.StringBuilderPool.Return(sb);
                 }
             }
+        }
 
-
-            bool MainloopTimer_ProcessKnockOut(PlayerSlot slot)
+        private bool MainloopTimer_ProcessKnockOut(PlayerSlot slot)
+        {
+            if (slot.Player is not null && slot.Player.Ship != ShipType.Spec && slot.Player.Freq == slot.Team.Freq)
             {
-                if (slot.Player is not null && slot.Player.Ship != ShipType.Spec && slot.Player.Freq == slot.Team.Freq)
-                {
-                    _game.SetShip(slot.Player, ShipType.Spec);
-                }
-
-                return false;
+                _game.SetShip(slot.Player, ShipType.Spec);
             }
+
+            return false;
         }
 
         // This is called synchronously when the Game module sets a player's ship/freq, before the ship/freq change packet is sent.
@@ -6812,6 +6811,10 @@ namespace SS.Matchmaking.Modules
 
             // Change the status to stop any additional attempts to end the match while we're ending it.
             matchData.Status = MatchStatus.Complete;
+
+            // Cancel any pending knockout-processing timers so that they can't later fire
+            // against a slot after it's been reassigned to a different player in a future match.
+            _mainloopTimer.ClearTimer<PlayerSlot>(MainloopTimer_ProcessKnockOut, matchData);
 
             MatchEndingCallback.Fire(_broker, matchData);
 


### PR DESCRIPTION
## Summary
- MainloopTimer_ProcessKnockOut delays moving a knocked-out player to spectator mode for a short time (min of WinConditionDelay and half the kill-enter-delay setting), to allow for a double-kill before removing the player from the ship.
- It was previously a local function nested inside Callback_Kill, which meant it could never be referenced from EndMatch to cancel a pending timer -- the mainloop timer API requires the exact same delegate to both set and clear a timer, and local functions aren't reachable outside their enclosing method.
- Because of this, if a match ended (by another means, e.g. time limit or an admin/ready-related cancellation) shortly after a knockout, while that knockout's timer was still pending, the timer survived match end.
- Since matchmaking reuses the same PlayerSlot objects for the next match hosted in the same box, the stale timer could later fire against a slot now assigned to a different player in a brand new match, forcing that unrelated player into spectator mode.

## Fix
- Hoisted MainloopTimer_ProcessKnockOut out of Callback_Kill into a proper private instance method (same body, same behavior), so it's referenceable elsewhere in the class.
- EndMatch now clears any pending MainloopTimer_ProcessKnockOut timers for the match (keyed by MatchData, matching how it's scheduled) as soon as it starts ending.

## Test plan
- [ ] Configure a very short WinConditionDelay / kill-enter-delay, get a knockout, and immediately end the match through another path (e.g. time limit or a draw) before the knockout timer would have fired. Start a new match in the same box and verify no player is unexpectedly forced into spectator mode shortly after the new match starts.