### PR TITLE
Fix TeamVersus not ending an active match when its arena is destroyed

### DIFF
--- a/src/Matchmaking/Modules/TeamVersusMatch.cs
+++ b/src/Matchmaking/Modules/TeamVersusMatch.cs
@@ -924,13 +924,31 @@ namespace SS.Matchmaking.Modules
                     _arenaDataPool.Return(arenaData);
                 }
 
-                // Clear arena for associated matches.
+                // Clear arena for associated matches, ending any that were still active.
+                // Snapshot into a separate list first since EndMatch can remove entries from
+                // _matchDataDictionary (e.g. for league matches), which would otherwise invalidate
+                // this enumeration.
+                List<MatchData> affectedMatches = new();
                 foreach (MatchData matchData in _matchDataDictionary.Values)
                 {
                     if (matchData.Arena == arena)
                     {
-                        matchData.Arena = null;
+                        affectedMatches.Add(matchData);
                     }
+                }
+
+                foreach (MatchData matchData in affectedMatches)
+                {
+                    if (matchData.Status != MatchStatus.None)
+                    {
+                        // The match was still active (or pending reset) when its arena was destroyed.
+                        // End it so that its slots, participation list, and player-slot dictionary
+                        // entries get cleaned up, rather than leaving the match permanently stuck
+                        // and the box permanently unavailable for a new match.
+                        EndMatch(matchData, MatchEndReason.Cancelled, null);
+                    }
+
+                    matchData.Arena = null;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- On ArenaAction.Destroy, any MatchData that still referenced the destroyed arena just had its Arena property set to null. The match itself was never ended.
- If that match was still active (any status other than None -- Initializing, StartingCheck, StartingCountdown, Starting, InProgress, or even Complete if caught mid-teardown) when the arena went away, this left it permanently stuck:
  - Its Status never returns to None, so TryGetAvailableMatch can never consider that box available for a new match again.
  - Its ParticipationList / the module-level _playerSlotDictionary entries for its participants are never cleared, so those players could remain permanently "already assigned" to a slot and be unable to join any future match.
- EndMatch already tolerates a missing arena (`Arena? arena = _arenaManager.FindArena(matchData.ArenaName); // Note: this can be null (the arena can be destroyed before the match ends)`), which is strong evidence it was intended to run in exactly this situation -- the arena-destroy handler just never called it.

## Fix
For each MatchData tied to the destroyed arena whose Status isn't already None, call `EndMatch(matchData, MatchEndReason.Cancelled, null)` before nulling out its Arena reference. The affected matches are snapshotted into a separate list before iterating, since EndMatch can remove entries from _matchDataDictionary (for league matches, and for matchmaking matches whose configuration changed), which would otherwise invalidate enumerating _matchDataDictionary.Values directly.

## Test plan
- [ ] Start a matchmaking or league match, then force the arena to be destroyed while the match is in progress (e.g. via an admin recycle/destroy path). Verify the match ends (participants get properly unassigned / can queue again) instead of leaving the box permanently stuck and the players permanently blocked.