### PR TITLE
Balls: add game lifecycle callbacks and per-ball custom-game scoring

### DIFF
--- a/src/Core/ComponentCallbacks/BallGameOverCallback.cs
+++ b/src/Core/ComponentCallbacks/BallGameOverCallback.cs
@@ -1,14 +1,15 @@
 namespace SS.Core.ComponentCallbacks
 {
     /// <summary>
-    /// Callback fired when a ball game ends in an arena — either a team won or the game was reset. Fired by the
-    /// <see cref="SS.Core.Modules.Scoring.BallGamePoints"/> module.
+    /// Callback fired when a ball game ends in an arena (any <see cref="SS.Core.ComponentInterfaces.IBalls.EndGame"/>
+    /// call — a team won, the timer ran out, or the game was reset). Fired by the <see cref="SS.Core.Modules.Balls"/>
+    /// module.
     /// </summary>
     [CallbackHelper]
     public static partial class BallGameOverCallback
     {
         /// <param name="arena">The arena the game ended in.</param>
-        /// <param name="winnerFreq">The winning freq, or <c>-1</c> if the game was reset with no winner.</param>
+        /// <param name="winnerFreq">The winning freq (reported by the caller of <see cref="SS.Core.ComponentInterfaces.IBalls.EndGame"/>), or <c>-1</c> when the game ended with no single winner (timer, reset, etc.).</param>
         public delegate void BallGameOverDelegate(Arena arena, short winnerFreq);
     }
 }

--- a/src/Core/ComponentCallbacks/BallGameOverCallback.cs
+++ b/src/Core/ComponentCallbacks/BallGameOverCallback.cs
@@ -1,0 +1,14 @@
+namespace SS.Core.ComponentCallbacks
+{
+    /// <summary>
+    /// Callback fired when a ball game ends in an arena — either a team won or the game was reset. Fired by the
+    /// <see cref="SS.Core.Modules.Scoring.BallGamePoints"/> module.
+    /// </summary>
+    [CallbackHelper]
+    public static partial class BallGameOverCallback
+    {
+        /// <param name="arena">The arena the game ended in.</param>
+        /// <param name="winnerFreq">The winning freq, or <c>-1</c> if the game was reset with no winner.</param>
+        public delegate void BallGameOverDelegate(Arena arena, short winnerFreq);
+    }
+}

--- a/src/Core/ComponentCallbacks/BallGameStartCallback.cs
+++ b/src/Core/ComponentCallbacks/BallGameStartCallback.cs
@@ -1,0 +1,12 @@
+namespace SS.Core.ComponentCallbacks
+{
+    /// <summary>
+    /// Callback fired when a ball game becomes active in an arena (the first pickup of a scoring ball after the game was
+    /// idle). Fired by the <see cref="SS.Core.Modules.Scoring.BallGamePoints"/> module.
+    /// </summary>
+    [CallbackHelper]
+    public static partial class BallGameStartCallback
+    {
+        public delegate void BallGameStartDelegate(Arena arena);
+    }
+}

--- a/src/Core/ComponentCallbacks/BallGameStartCallback.cs
+++ b/src/Core/ComponentCallbacks/BallGameStartCallback.cs
@@ -1,8 +1,8 @@
 namespace SS.Core.ComponentCallbacks
 {
     /// <summary>
-    /// Callback fired when a ball game becomes active in an arena (the first pickup of a scoring ball after the game was
-    /// idle). Fired by the <see cref="SS.Core.Modules.Scoring.BallGamePoints"/> module.
+    /// Callback fired when a ball game (re)starts in an arena — when the first ball spawns after the game had ended
+    /// (or after the ball count was set to 0). Fired by the <see cref="SS.Core.Modules.Balls"/> module.
     /// </summary>
     [CallbackHelper]
     public static partial class BallGameStartCallback

--- a/src/Core/ComponentInterfaces/IBalls.cs
+++ b/src/Core/ComponentInterfaces/IBalls.cs
@@ -181,10 +181,11 @@ namespace SS.Core.ComponentInterfaces
         bool TrySpawnBall(Arena arena, int ballId);
 
         /// <summary>
-        /// Ends the ball game. This phases balls which will respawn.
+        /// Ends the ball game. This phases balls which will respawn. Fires <see cref="ComponentCallbacks.BallGameOverCallback"/>.
         /// </summary>
         /// <param name="arena">The arena to end the ball game for.</param>
-        void EndGame(Arena arena);
+        /// <param name="winnerFreq">The winning freq to report to <see cref="ComponentCallbacks.BallGameOverCallback"/>, or <c>-1</c> when the game ended with no single winner (timer, reset, etc.).</param>
+        void EndGame(Arena arena, short winnerFreq = -1);
 
         /// <summary>
         /// Gets goal info for a coordinate in an arena, for a given team.

--- a/src/Core/Modules/Balls.cs
+++ b/src/Core/Modules/Balls.cs
@@ -1185,7 +1185,7 @@ namespace SS.Core.Modules
 
             lock (ad.Lock)
             {
-                if (ballId > ad.BallCount)
+                if (ballId >= ad.BallCount)
                     return;
 
                 ref BallData bd = ref ad.Balls[ballId];

--- a/src/Core/Modules/Balls.cs
+++ b/src/Core/Modules/Balls.cs
@@ -200,10 +200,11 @@ namespace SS.Core.Modules
                     ad.Balls[i].Time = ServerTick.Now + (uint)newGameDelay;
             }
 
-            // The ball game is over — notify subscribers. Fired outside ad.Lock (unlike the other ball callbacks,
-            // which fire inside it) so a handler is free to call back into IBalls.EndGame/TrySetBallCount without
-            // running under the lock. Only fire on the active->ended transition, so a second EndGame in the same goal
-            // (e.g. a golden goal that also satisfies the win condition) doesn't fire BallGameOver twice.
+            // The ball game is over — notify subscribers. Fired after releasing EndGame's own ad.Lock (the other ball
+            // callbacks fire while holding it). A subscriber may still be under the lock re-entrantly when EndGame was
+            // reached from a locked path (e.g. a goal: HandleGoal -> BallGoal -> CheckGameOver -> EndGame); ad.Lock is
+            // reentrant so that is safe. Only fire on the active->ended transition, so a second EndGame in the same
+            // goal (e.g. a golden goal that also satisfies the win condition) doesn't fire BallGameOver twice.
             // winnerFreq is -1 unless the caller (e.g. the scorer) reported a winning freq.
             if (!alreadyEnded)
                 BallGameOverCallback.Fire(arena, arena, winnerFreq);

--- a/src/Core/Modules/Balls.cs
+++ b/src/Core/Modules/Balls.cs
@@ -178,8 +178,11 @@ namespace SS.Core.Modules
             if (!arena.TryGetExtraData(_adKey, out ArenaData? ad))
                 return;
 
+            bool alreadyEnded;
             lock (ad.Lock)
             {
+                alreadyEnded = ad.GameEnded;
+
                 for (int i = 0; i < ad.BallCount; i++)
                 {
                     PhaseBall(arena, i);
@@ -198,8 +201,11 @@ namespace SS.Core.Modules
             }
 
             // The ball game is over — notify subscribers. Fired outside the lock so handlers may call back into IBalls.
+            // Only fire on the active->ended transition, so a second EndGame in the same goal (e.g. a golden goal
+            // that also satisfies the win condition) doesn't fire BallGameOver twice.
             // ASSS's CB_BALLGAMEOVER carries no winner; -1 means "ended with no specific winner reported here".
-            BallGameOverCallback.Fire(arena, arena, -1);
+            if (!alreadyEnded)
+                BallGameOverCallback.Fire(arena, arena, -1);
 
             IPersistExecutor? persistExecutor = _broker.GetInterface<IPersistExecutor>();
             if (persistExecutor != null)

--- a/src/Core/Modules/Balls.cs
+++ b/src/Core/Modules/Balls.cs
@@ -170,7 +170,7 @@ namespace SS.Core.Modules
 
         [ConfigHelp<int>("Soccer", "NewGameDelay", ConfigScope.Arena, Default = -3000,
             Description = "How long to wait between games (in ticks). If this is negative, the actual delay is random, between zero and the absolute value.")]
-        void IBalls.EndGame(Arena arena)
+        void IBalls.EndGame(Arena arena, short winnerFreq)
         {
             if (arena == null)
                 return;
@@ -200,12 +200,13 @@ namespace SS.Core.Modules
                     ad.Balls[i].Time = ServerTick.Now + (uint)newGameDelay;
             }
 
-            // The ball game is over — notify subscribers. Fired outside the lock so handlers may call back into IBalls.
-            // Only fire on the active->ended transition, so a second EndGame in the same goal (e.g. a golden goal
-            // that also satisfies the win condition) doesn't fire BallGameOver twice.
-            // ASSS's CB_BALLGAMEOVER carries no winner; -1 means "ended with no specific winner reported here".
+            // The ball game is over — notify subscribers. Fired outside ad.Lock (unlike the other ball callbacks,
+            // which fire inside it) so a handler is free to call back into IBalls.EndGame/TrySetBallCount without
+            // running under the lock. Only fire on the active->ended transition, so a second EndGame in the same goal
+            // (e.g. a golden goal that also satisfies the win condition) doesn't fire BallGameOver twice.
+            // winnerFreq is -1 unless the caller (e.g. the scorer) reported a winning freq.
             if (!alreadyEnded)
-                BallGameOverCallback.Fire(arena, arena, -1);
+                BallGameOverCallback.Fire(arena, arena, winnerFreq);
 
             IPersistExecutor? persistExecutor = _broker.GetInterface<IPersistExecutor>();
             if (persistExecutor != null)

--- a/src/Core/Modules/Balls.cs
+++ b/src/Core/Modules/Balls.cs
@@ -187,6 +187,8 @@ namespace SS.Core.Modules
                     ad.Balls[i].Carrier = null;
                 }
 
+                ad.GameEnded = true;
+
                 int newGameDelay = _configManager.GetInt(arena.Cfg!, "Soccer", "NewGameDelay", SoccerSettings.NewGameDelay.Default);
                 if (newGameDelay < 0)
                     newGameDelay = _prng.Number(0, -newGameDelay);
@@ -194,6 +196,10 @@ namespace SS.Core.Modules
                 for (int i = 0; i < ad.BallCount; i++)
                     ad.Balls[i].Time = ServerTick.Now + (uint)newGameDelay;
             }
+
+            // The ball game is over — notify subscribers. Fired outside the lock so handlers may call back into IBalls.
+            // ASSS's CB_BALLGAMEOVER carries no winner; -1 means "ended with no specific winner reported here".
+            BallGameOverCallback.Fire(arena, arena, -1);
 
             IPersistExecutor? persistExecutor = _broker.GetInterface<IPersistExecutor>();
             if (persistExecutor != null)
@@ -949,6 +955,10 @@ namespace SS.Core.Modules
 
                 ad.BallCount = newBallCount;
 
+                // Dropping to zero balls stops the game (mirrors ASSS StopGame); the next spawn will fire BallGameStart.
+                if (newBallCount == 0)
+                    ad.GameEnded = true;
+
                 if (newBallCount > oldBallCount)
                 {
                     for (int i = oldBallCount; i < newBallCount; i++)
@@ -1067,6 +1077,13 @@ namespace SS.Core.Modules
                 d.Y = sy;
 
                 TryPlaceBall(arena, ballId, ref d);
+
+                // The first ball to spawn after a game-over (or stop) starts a new ball game. Mirrors ASSS SpawnBall.
+                if (ad.GameEnded)
+                {
+                    ad.GameEnded = false;
+                    BallGameStartCallback.Fire(arena, arena);
+                }
             }
 
             return true;
@@ -1398,6 +1415,13 @@ namespace SS.Core.Modules
             /// </summary>
             public bool BallCountOverridden;
 
+            /// <summary>
+            /// Whether the ball game has ended (or has not started yet). Set by <see cref="IBalls.EndGame"/> and whenever
+            /// the ball count drops to 0 (a game stop); cleared when a ball next spawns, which is the moment
+            /// <see cref="BallGameStartCallback"/> fires. Mirrors ASSS <c>balls.c</c>'s <c>gameEnded</c> flag.
+            /// </summary>
+            public bool GameEnded;
+
             #endregion
 
             public readonly Lock Lock = new();
@@ -1424,6 +1448,7 @@ namespace SS.Core.Modules
                     LastSendTime = default;
                     Settings = default;
                     BallCountOverridden = false;
+                    GameEnded = false;
                 }
 
                 return true;

--- a/src/Core/Modules/GameTimer.cs
+++ b/src/Core/Modules/GameTimer.cs
@@ -381,20 +381,30 @@ namespace SS.Core.Modules
 
                         GameTimerEndedCallback.Fire(arena, arena);
 
-                        if (ad.GameLength > TimeSpan.Zero)
+                        // A GameTimerEnded handler may have restarted the timer during the callback (e.g. a league
+                        // module adding golden-goal extra time via IGameTimer.SetTimer). If it set a new future
+                        // ending, honor it — don't stop/restart the timer or announce game over.
+                        if (ad.EndingTimestamp.HasValue && ad.EndingTimestamp.Value > now)
                         {
-                            if (ad.Start(now))
-                            {
-                                GameTimerChangedCallback.Fire(arena, arena, TimerChange.Started, TimerChangeReason.Completion, ad.GameLength != TimeSpan.Zero);
-                            }
+                            // Timer was restarted by a callback; leave it running.
                         }
                         else
                         {
-                            ad.Stop();
-                            GameTimerChangedCallback.Fire(arena, arena, TimerChange.Stopped, TimerChangeReason.Completion, ad.GameLength != TimeSpan.Zero);
-                        }
+                            if (ad.GameLength > TimeSpan.Zero)
+                            {
+                                if (ad.Start(now))
+                                {
+                                    GameTimerChangedCallback.Fire(arena, arena, TimerChange.Started, TimerChangeReason.Completion, ad.GameLength != TimeSpan.Zero);
+                                }
+                            }
+                            else
+                            {
+                                ad.Stop();
+                                GameTimerChangedCallback.Fire(arena, arena, TimerChange.Stopped, TimerChangeReason.Completion, ad.GameLength != TimeSpan.Zero);
+                            }
 
-                        _chat.SendArenaMessage(arena, ChatSound.Hallellula, $"NOTICE: Game over");
+                            _chat.SendArenaMessage(arena, ChatSound.Hallellula, $"NOTICE: Game over");
+                        }
                     }
                 }
             }

--- a/src/Core/Modules/Scoring/BallGamePoints.cs
+++ b/src/Core/Modules/Scoring/BallGamePoints.cs
@@ -216,7 +216,12 @@ namespace SS.Core.Modules.Scoring
                 // Steal scoring only applies when CapturePoints is positive. CapturePoints <= 0 means absolute scoring
                 // (0 would otherwise start every team with an empty pool, making it impossible to ever score).
                 ad.IsStealPoints = ad.CapturePoints > 0;
-                ResetTeamScores(ad);
+
+                // Only reset the scores on Create. A ConfChanged fires on any arena config write (e.g. MultiPub
+                // changing game-type settings), and wiping the score mid-game would break "change the map but keep
+                // the game going". A new game resets scores via EndGame instead.
+                if (action == ArenaAction.Create)
+                    ResetTeamScores(ad);
             }
         }
 

--- a/src/Core/Modules/Scoring/BallGamePoints.cs
+++ b/src/Core/Modules/Scoring/BallGamePoints.cs
@@ -193,7 +193,9 @@ namespace SS.Core.Modules.Scoring
             Description = """
                 A bitmask, indexed by ball id, of balls that this module should NOT score. For each such ball, another
                 module is expected to do its own goal handling (e.g. a PowerBall side-game). Bit 0 = ball 0. For a
-                single-ball arena, a value of 1 has the same effect as the old boolean 'custom game' flag.
+                single-ball arena, a value of 1 has the same effect as the old boolean 'custom game' flag. Note the
+                compatibility caveat for multi-ball arenas: previously any non-zero value meant "custom-game all balls",
+                whereas now a value of 1 excludes only ball 0 — set the mask bits for every ball you want excluded.
                 """)]
         private void Callback_ArenaAction(Arena arena, ArenaAction action)
         {
@@ -480,7 +482,7 @@ namespace SS.Core.Modules.Scoring
             {
                 _chat.SendArenaMessage(arena, ChatSound.Ding, $"Soccer game over.");
                 int points = RewardPoints(arena, freq);
-                _balls.EndGame(arena); // fires BallGameOver
+                _balls.EndGame(arena, freq); // fires BallGameOver with the winning freq
                 ResetTeamScores(ad);
 
                 // Note: ASSS doesn't send score stats updates here because it relies on the IBalls.EndGame to end the 'game' interval,

--- a/src/Core/Modules/Scoring/BallGamePoints.cs
+++ b/src/Core/Modules/Scoring/BallGamePoints.cs
@@ -339,8 +339,8 @@ namespace SS.Core.Modules.Scoring
             Args = "<freq 0 score> [<freq 1 score> [... [<freq 7 score>]]]",
             Description = """
                 Changes score of current soccer game, based on arguments. Only supports
-                first eight freqs, and arena must be in absolute scoring mode 
-                (Soccer:CapturePoints < 0).
+                first eight freqs, and arena must be in absolute scoring mode
+                (Soccer:CapturePoints <= 0).
                 """)]
         private void Command_setscore(ReadOnlySpan<char> commandName, ReadOnlySpan<char> parameters, Player player, ITarget target)
         {
@@ -356,7 +356,7 @@ namespace SS.Core.Modules.Scoring
 
             if (ad.IsStealPoints)
             {
-                _chat.SendMessage(player, "Arena must be using absolute scoring (Soccer:CapturePoints < 0).");
+                _chat.SendMessage(player, "Arena must be using absolute scoring (Soccer:CapturePoints <= 0).");
                 return;
             }
 

--- a/src/Core/Modules/Scoring/BallGamePoints.cs
+++ b/src/Core/Modules/Scoring/BallGamePoints.cs
@@ -89,12 +89,14 @@ namespace SS.Core.Modules.Scoring
 
             ArenaActionCallback.Register(arena, Callback_ArenaAction);
             BallGoalCallback.Register(arena, Callback_BallGoal);
+            BallPickupCallback.Register(arena, Callback_BallPickup);
 
             _commandManager.AddCommand("setscore", Command_setscore, arena);
             _commandManager.AddCommand("score", Command_score, arena);
             _commandManager.AddCommand("resetgame", Command_resetgame, arena);
 
             ad.BallsAdvisorToken = arena.RegisterAdvisor<IBallsAdvisor>(this);
+            ad.InterfaceToken = arena.RegisterInterface<IBallGamePoints>(this);
 
             return true;
         }
@@ -104,6 +106,9 @@ namespace SS.Core.Modules.Scoring
             if (!arena.TryGetExtraData(_adKey, out ArenaData? ad))
                 return false;
 
+            if (ad.InterfaceToken is not null)
+                arena.UnregisterInterface(ref ad.InterfaceToken);
+
             arena.UnregisterAdvisor(ref ad.BallsAdvisorToken);
 
             _commandManager.RemoveCommand("setscore", Command_setscore, arena);
@@ -112,6 +117,7 @@ namespace SS.Core.Modules.Scoring
 
             ArenaActionCallback.Unregister(arena, Callback_ArenaAction);
             BallGoalCallback.Unregister(arena, Callback_BallGoal);
+            BallPickupCallback.Unregister(arena, Callback_BallPickup);
 
             return true;
         }
@@ -153,7 +159,12 @@ namespace SS.Core.Modules.Scoring
 
         bool IBallsAdvisor.AllowGoal(Arena arena, Player player, int ballId, TileCoordinates coordinates, ref BallData ballData)
         {
-            // Allow the goal if the tile is a goal and it can be scored on by the player's freq.
+            // A ball whose CustomGame bit is set is owned by another module; always allow it so its goal fires
+            // BallGoalCallback (which that module handles) and the ball respawns.
+            if (arena.TryGetExtraData(_adKey, out ArenaData? ad) && (ad.CustomGameMask & (1 << ballId)) != 0)
+                return true;
+
+            // Otherwise allow the goal if the tile is a goal and it can be scored on by the player's freq.
             _balls.GetGoalInfo(arena, player.Freq, coordinates, out bool isScoreable, out _);
             return isScoreable;
         }
@@ -180,14 +191,19 @@ namespace SS.Core.Modules.Scoring
             Description = "The minimum number of players who must be playing for soccer points to be awarded.")]
         [ConfigHelp<int>("Soccer", "MinTeams", ConfigScope.Arena, Default = 0,
             Description = "The minimum number of teams that must exist for soccer points to be awarded.")]
+        [ConfigHelp<int>("Soccer", "CustomGame", ConfigScope.Arena, Default = 0,
+            Description = """
+                A bitmask, indexed by ball id, of balls that this module should NOT score. For each such ball, another
+                module is expected to do its own goal handling (e.g. a PowerBall side-game). Bit 0 = ball 0. For a
+                single-ball arena, a value of 1 has the same effect as the old boolean 'custom game' flag.
+                """)]
         private void Callback_ArenaAction(Arena arena, ArenaAction action)
         {
             if (!arena.TryGetExtraData(_adKey, out ArenaData? ad))
                 return;
 
             if (action == ArenaAction.Create
-                // TODO: || action == ArenaAction.ConfChanged
-                )
+                || action == ArenaAction.ConfChanged)
             {
                 ConfigHandle ch = arena.Cfg!;
                 ad.Mode = _configManager.GetEnum(ch, "Soccer", "Mode", SoccerMode.All);
@@ -197,10 +213,26 @@ namespace SS.Core.Modules.Scoring
                 ad.MinPlayers = _configManager.GetInt(ch, "Soccer", "MinPlayers", SoccerSettings.MinPlayers.Default);
                 ad.MinTeams = _configManager.GetInt(ch, "Soccer", "MinTeams", SoccerSettings.MinTeams.Default);
                 ad.IsFrequencyShipTypes = _configManager.GetInt(ch, "Misc", "FrequencyShipTypes", 0) != 0;
-                ad.IsCustomGame = _configManager.GetInt(ch, "Soccer", "CustomGame", 0) != 0;
+                ad.CustomGameMask = _configManager.GetInt(ch, "Soccer", "CustomGame", 0);
 
                 ad.IsStealPoints = ad.CapturePoints >= 0;
                 ResetTeamScores(ad);
+            }
+        }
+
+        private void Callback_BallPickup(Arena arena, Player player, byte ballId)
+        {
+            if (!arena.TryGetExtraData(_adKey, out ArenaData? ad))
+                return;
+
+            // A ball whose CustomGame bit is set is scored by another module; it doesn't start this game.
+            if ((ad.CustomGameMask & (1 << ballId)) != 0)
+                return;
+
+            if (!ad.IsGameActive)
+            {
+                ad.IsGameActive = true;
+                BallGameStartCallback.Fire(arena, arena);
             }
         }
 
@@ -209,14 +241,12 @@ namespace SS.Core.Modules.Scoring
             if (!arena.TryGetExtraData(_adKey, out ArenaData? ad))
                 return;
 
-            if (ad.IsCustomGame)
-                return; // custom soccer games do their own goal handling (e.g. scramble)
+            // A ball whose CustomGame bit is set is scored by another module (e.g. a PowerBall side-game).
+            if ((ad.CustomGameMask & (1 << ballId)) != 0)
+                return;
 
-            //if (!_balls.TryGetBallData(arena, ballId, out BallData ballData))
-            //return;
-
-            short scoringFreq = player.Freq; // TODO: investigate how ASSS has a value other than -1 when it accesses ballData.Freq;
-            if (scoringFreq < 0)
+            short scoringFreq = player.Freq;
+            if (scoringFreq < 0 || scoringFreq >= MaxTeams)
                 return;
 
             _balls.GetGoalInfo(arena, scoringFreq, goalCoordinates, out _, out short? ownerFreq);
@@ -459,6 +489,8 @@ namespace SS.Core.Modules.Scoring
                 int points = RewardPoints(arena, freq);
                 _balls.EndGame(arena);
                 ResetTeamScores(ad);
+                ad.IsGameActive = false;
+                BallGameOverCallback.Fire(arena, arena, freq);
 
                 // Note: ASSS doesn't send score stats updates here because it relies on the IBalls.EndGame to end the 'game' interval,
                 // which triggers the score updates. However, in this server, it only triggers an update if it's on the 'reset' interval.
@@ -513,6 +545,9 @@ namespace SS.Core.Modules.Scoring
                         // no score message
                         break;
                 }
+
+                if (sb.Length == 0)
+                    return;
 
                 if (player != null)
                     _chat.SendMessage(player, sb);
@@ -635,6 +670,8 @@ namespace SS.Core.Modules.Scoring
 
                 _balls.EndGame(arena);
                 ResetTeamScores(ad);
+                ad.IsGameActive = false;
+                BallGameOverCallback.Fire(arena, arena, -1);
             }
         }
 
@@ -660,6 +697,7 @@ namespace SS.Core.Modules.Scoring
         private class ArenaData : IResettable
         {
             public AdvisorRegistrationToken<IBallsAdvisor>? BallsAdvisorToken;
+            public InterfaceRegistrationToken<IBallGamePoints>? InterfaceToken;
 
             // settings
             public SoccerMode Mode;
@@ -670,14 +708,20 @@ namespace SS.Core.Modules.Scoring
             public int MinPlayers;
             public int MinTeams;
             public bool IsFrequencyShipTypes;
-            public bool IsCustomGame;
+
+            /// <summary>Bitmask, indexed by ball id, of balls this module should NOT score (another module owns them).</summary>
+            public int CustomGameMask;
 
             // state
             public readonly int[] TeamScores = new int[MaxTeams];
 
+            /// <summary>Whether a game is currently in progress (set on the first scoring-ball pickup, cleared on game over).</summary>
+            public bool IsGameActive;
+
             public bool TryReset()
             {
                 BallsAdvisorToken = null;
+                InterfaceToken = null;
                 Mode = SoccerMode.All;
                 CapturePoints = 0;
                 IsStealPoints = false;
@@ -686,8 +730,9 @@ namespace SS.Core.Modules.Scoring
                 MinPlayers = 0;
                 MinTeams = 0;
                 IsFrequencyShipTypes = false;
-                IsCustomGame = false;
+                CustomGameMask = 0;
                 Array.Clear(TeamScores);
+                IsGameActive = false;
                 return true;
             }
         }

--- a/src/Core/Modules/Scoring/BallGamePoints.cs
+++ b/src/Core/Modules/Scoring/BallGamePoints.cs
@@ -89,7 +89,6 @@ namespace SS.Core.Modules.Scoring
 
             ArenaActionCallback.Register(arena, Callback_ArenaAction);
             BallGoalCallback.Register(arena, Callback_BallGoal);
-            BallPickupCallback.Register(arena, Callback_BallPickup);
 
             _commandManager.AddCommand("setscore", Command_setscore, arena);
             _commandManager.AddCommand("score", Command_score, arena);
@@ -117,7 +116,6 @@ namespace SS.Core.Modules.Scoring
 
             ArenaActionCallback.Unregister(arena, Callback_ArenaAction);
             BallGoalCallback.Unregister(arena, Callback_BallGoal);
-            BallPickupCallback.Unregister(arena, Callback_BallPickup);
 
             return true;
         }
@@ -215,24 +213,10 @@ namespace SS.Core.Modules.Scoring
                 ad.IsFrequencyShipTypes = _configManager.GetInt(ch, "Misc", "FrequencyShipTypes", 0) != 0;
                 ad.CustomGameMask = _configManager.GetInt(ch, "Soccer", "CustomGame", 0);
 
-                ad.IsStealPoints = ad.CapturePoints >= 0;
+                // Steal scoring only applies when CapturePoints is positive. CapturePoints <= 0 means absolute scoring
+                // (0 would otherwise start every team with an empty pool, making it impossible to ever score).
+                ad.IsStealPoints = ad.CapturePoints > 0;
                 ResetTeamScores(ad);
-            }
-        }
-
-        private void Callback_BallPickup(Arena arena, Player player, byte ballId)
-        {
-            if (!arena.TryGetExtraData(_adKey, out ArenaData? ad))
-                return;
-
-            // A ball whose CustomGame bit is set is scored by another module; it doesn't start this game.
-            if ((ad.CustomGameMask & (1 << ballId)) != 0)
-                return;
-
-            if (!ad.IsGameActive)
-            {
-                ad.IsGameActive = true;
-                BallGameStartCallback.Fire(arena, arena);
             }
         }
 
@@ -437,7 +421,11 @@ namespace SS.Core.Modules.Scoring
             if (ad.IsStealPoints
                 && (ad.Mode == SoccerMode.LeftRight || ad.Mode == SoccerMode.TopBottom))
             {
-                if (ad.TeamScores[(~freq) + 2] == 0)
+                // In a 2-team game the other team is (~freq)+2 (i.e. 1-freq). Guard the index in case a goal was
+                // scored on a freq >= 2 (which shouldn't happen in these modes but must not throw if it does).
+                int opponentFreq = (~freq) + 2;
+                if (opponentFreq >= 0 && opponentFreq < ad.TeamScores.Length
+                    && ad.TeamScores[opponentFreq] == 0)
                 {
                     // The opposing team doesn't have any points left.
                     EndGame(arena, ad, freq);
@@ -487,10 +475,8 @@ namespace SS.Core.Modules.Scoring
             {
                 _chat.SendArenaMessage(arena, ChatSound.Ding, $"Soccer game over.");
                 int points = RewardPoints(arena, freq);
-                _balls.EndGame(arena);
+                _balls.EndGame(arena); // fires BallGameOver
                 ResetTeamScores(ad);
-                ad.IsGameActive = false;
-                BallGameOverCallback.Fire(arena, arena, freq);
 
                 // Note: ASSS doesn't send score stats updates here because it relies on the IBalls.EndGame to end the 'game' interval,
                 // which triggers the score updates. However, in this server, it only triggers an update if it's on the 'reset' interval.
@@ -519,7 +505,7 @@ namespace SS.Core.Modules.Scoring
                         }
                         else
                         {
-                            sb.Append($"SCORE: Even:{ad.TeamScores[0]} Odds:{ad.TeamScores[1]}");
+                            sb.Append($"SCORE: Evens:{ad.TeamScores[0]} Odds:{ad.TeamScores[1]}");
                         }
 
                         break;
@@ -668,10 +654,8 @@ namespace SS.Core.Modules.Scoring
 
                 _chat.SendArenaMessage(arena, ChatSound.Ding, $"Soccer game over.");
 
-                _balls.EndGame(arena);
+                _balls.EndGame(arena); // fires BallGameOver
                 ResetTeamScores(ad);
-                ad.IsGameActive = false;
-                BallGameOverCallback.Fire(arena, arena, -1);
             }
         }
 
@@ -715,9 +699,6 @@ namespace SS.Core.Modules.Scoring
             // state
             public readonly int[] TeamScores = new int[MaxTeams];
 
-            /// <summary>Whether a game is currently in progress (set on the first scoring-ball pickup, cleared on game over).</summary>
-            public bool IsGameActive;
-
             public bool TryReset()
             {
                 BallsAdvisorToken = null;
@@ -732,7 +713,6 @@ namespace SS.Core.Modules.Scoring
                 IsFrequencyShipTypes = false;
                 CustomGameMask = 0;
                 Array.Clear(TeamScores);
-                IsGameActive = false;
                 return true;
             }
         }


### PR DESCRIPTION
Extend BallGamePoints so other modules can build ball games on top of it:

- Treat Soccer:CustomGame as a bitmask indexed by ball id, so a specific ball can be excluded from scoring while another module handles it. A ball whose bit is set is passed through AllowGoal (so its goal still fires and the ball respawns) but is not scored here. Backward compatible for single-ball arenas, where a value of 1 still means "don't score ball 0".
- Register IBallGamePoints per attached arena so other modules can read and reset the team scores.
- Fire two new callbacks off the ball-game lifecycle: BallGameStart (on the first scoring-ball pickup) and BallGameOver (on a win or a reset).
- Guard the scoring freq against the team-score array bounds.
- Reload settings on ArenaAction.ConfChanged.